### PR TITLE
[1.x] Add description for services within the `config-orchestration.stub` file. 

### DIFF
--- a/stubs/config-orchestration.stub
+++ b/stubs/config-orchestration.stub
@@ -2,6 +2,16 @@
 
 return [
 
+    /*
+    |--------------------------------------------------------------------------
+    | Orchestration Services
+    |--------------------------------------------------------------------------
+    |
+    | Here you can specify all of the application's services that need
+    | to be wrapped by the orchestration service layer. Each one must
+    | be keyed by it's id and provide the name of it's config file.
+    |
+    */
     'services' => [
 
         '{{ id }}' => [


### PR DESCRIPTION
### **What does this PR do?** :robot:
- Adds comment to the `services` key of the `config-orchestration.stub` file describing what it is meant for.

### **Does this relate to any issue?** :link:
Closes #23 
