### PR TITLE
[1.x] Fix database driver dependency resolution.

### DIFF
--- a/database/migrations/0001_01_01_000001_create_base_orchestration_tables.php
+++ b/database/migrations/0001_01_01_000001_create_base_orchestration_tables.php
@@ -19,12 +19,12 @@ class CreateBaseOrchestrationTables extends Migration
         if ($usingDatabaseDriver) {
             Schema::create('services', function (Blueprint $table) {
                 $table->string('id')->primary();
-                $table->string('default_provider')->nullable();
-                $table->string('default_merchant')->nullable();
+                $table->string('default_provider_id')->nullable();
+                $table->string('default_merchant_id')->nullable();
                 $table->timestamps();
 
-                $table->foreign('default_provider')->references('id')->on('providers')->onDelete('set null');
-                $table->foreign('default_merchant')->references('id')->on('merchants')->onDelete('set null');
+                $table->foreign('default_provider_id')->references('id')->on('providers')->onUpdate('cascade')->onDelete('set null');
+                $table->foreign('default_merchant_id')->references('id')->on('merchants')->onUpdate('cascade')->onDelete('set null');
             });
 
             Schema::create('providers', function (Blueprint $table) {
@@ -40,16 +40,17 @@ class CreateBaseOrchestrationTables extends Migration
             Schema::create('merchants', function (Blueprint $table) {
                 $table->string('id')->primary();
                 $table->string('service_id');
+                $table->string('default_provider_id')->nullable();
                 $table->timestamps();
 
                 $table->foreign('service_id')->references('id')->on('services')->onUpdate('cascade')->onDelete('cascade');
+                $table->foreign('default_provider_id')->references('id')->on('providers')->onUpdate('cascade')->onDelete('set null');
             });
 
             Schema::create('merchant_provider', function (Blueprint $table) {
                 $table->increments('id');
                 $table->string('merchant_id');
                 $table->string('provider_id');
-                $table->boolean('is_default')->default(false);
                 $table->json('config')->nullable();
                 $table->timestamps();
 

--- a/database/migrations/0001_01_01_000001_create_base_orchestration_tables.php
+++ b/database/migrations/0001_01_01_000001_create_base_orchestration_tables.php
@@ -19,7 +19,12 @@ class CreateBaseOrchestrationTables extends Migration
         if ($usingDatabaseDriver) {
             Schema::create('services', function (Blueprint $table) {
                 $table->string('id')->primary();
+                $table->string('default_provider')->nullable();
+                $table->string('default_merchant')->nullable();
                 $table->timestamps();
+
+                $table->foreign('default_provider')->references('id')->on('providers')->onDelete('set null');
+                $table->foreign('default_merchant')->references('id')->on('merchants')->onDelete('set null');
             });
 
             Schema::create('providers', function (Blueprint $table) {
@@ -44,7 +49,7 @@ class CreateBaseOrchestrationTables extends Migration
                 $table->increments('id');
                 $table->string('merchant_id');
                 $table->string('provider_id');
-                $table->boolean('default')->default(false);
+                $table->boolean('is_default')->default(false);
                 $table->json('config')->nullable();
                 $table->timestamps();
 

--- a/src/DataTransferObjects/Service.php
+++ b/src/DataTransferObjects/Service.php
@@ -2,6 +2,7 @@
 
 namespace Payavel\Orchestration\DataTransferObjects;
 
+use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Str;
 use Payavel\Orchestration\Contracts\Serviceable;
 use Payavel\Orchestration\Traits\SimulatesAttributes;
@@ -33,5 +34,19 @@ class Service implements Serviceable
     public function getName()
     {
         return Str::headline($this->attributes['id']);
+    }
+
+    /**
+     * Create a new static instance from a serviceable.
+     *
+     * @param Serviceable $service
+     * @return static
+     */
+    public static function fromServiceable(Serviceable $service)
+    {
+        return new static(array_merge(
+            ['id' => $service->getId()],
+            Config::get('orchestration.services.' . $service->getId(), [])
+        ));
     }
 }

--- a/src/Drivers/ConfigDriver.php
+++ b/src/Drivers/ConfigDriver.php
@@ -4,6 +4,7 @@ namespace Payavel\Orchestration\Drivers;
 
 use Illuminate\Support\Facades\Config;
 use Payavel\Orchestration\Contracts\Merchantable;
+use Payavel\Orchestration\Contracts\Providable;
 use Payavel\Orchestration\Contracts\Serviceable;
 use Payavel\Orchestration\DataTransferObjects\Merchant;
 use Payavel\Orchestration\DataTransferObjects\Provider;
@@ -36,6 +37,21 @@ class ConfigDriver extends ServiceDriver
 
         $this->providers = collect($this->config($this->service->getId(), 'providers'));
         $this->merchants = collect($this->config($this->service->getId(), 'merchants'));
+    }
+
+    /**
+     * Resolve the serviceable instance.
+     *
+     * @param \Payavel\Orchestration\Contracts\Serviceable $service
+     * @return \Payavel\Orchestration\Contracts\Serviceable
+     */
+    public function resolveService(Serviceable $service)
+    {
+        if (! $service instanceof Service) {
+            $service = Service::fromServiceable($service);
+        }
+
+        return $service;
     }
 
     /**
@@ -72,7 +88,7 @@ class ConfigDriver extends ServiceDriver
             ! $merchant instanceof Merchant ||
             is_null($provider = $merchant->providers->first())
         ) {
-            return parent::getDefaultProvider();
+            return $this->config($this->service->getId(), 'defaults.provider');
         }
 
         return $provider['id'];
@@ -98,6 +114,17 @@ class ConfigDriver extends ServiceDriver
             $this->service,
             array_merge(['id' => $merchant], $attributes)
         );
+    }
+
+    /**
+     * Get the default merchantable identifier.
+     *
+     * @param \Payavel\Orchestration\Contracts\Providable|null $provider
+     * @return string|int
+     */
+    public function getDefaultMerchant(Providable $provider = null)
+    {
+        return $this->config($this->service->getId(), 'defaults.merchant');
     }
 
     /**

--- a/src/Drivers/DatabaseDriver.php
+++ b/src/Drivers/DatabaseDriver.php
@@ -3,6 +3,8 @@
 namespace Payavel\Orchestration\Drivers;
 
 use Payavel\Orchestration\Contracts\Merchantable;
+use Payavel\Orchestration\Contracts\Providable;
+use Payavel\Orchestration\Contracts\Serviceable;
 use Payavel\Orchestration\Models\Merchant;
 use Payavel\Orchestration\Models\Provider;
 use Payavel\Orchestration\Models\Service;
@@ -10,6 +12,31 @@ use Payavel\Orchestration\ServiceDriver;
 
 class DatabaseDriver extends ServiceDriver
 {
+    /**
+     * Resolve the serviceable instance.
+     *
+     * @param \Payavel\Orchestration\Contracts\Serviceable $service
+     * @return \Payavel\Orchestration\Contracts\Serviceable
+     */
+    public function resolveService(Serviceable $service)
+    {
+        if (! $service instanceof Service) {
+            $service = Service::find($service->getId());
+        }
+
+        return $service;
+    }
+
+    /**
+     * Refresh the service & all of it's loaded relations.
+     *
+     * @return void
+     */
+    public function refresh()
+    {
+        $this->service->refresh();
+    }
+
     /**
      * Resolve the providable instance.
      *
@@ -39,8 +66,8 @@ class DatabaseDriver extends ServiceDriver
      */
     public function getDefaultProvider(Merchantable $merchant = null)
     {
-        if (! $merchant instanceof Merchant || is_null($provider = $merchant->providers()->wherePivot('is_default', true)->first())) {
-            return parent::getDefaultProvider();
+        if (! $merchant instanceof Merchant || is_null($provider = $merchant->default_provider_id)) {
+            $provider = $this->service->default_provider_id;
         }
 
         return $provider;
@@ -65,6 +92,17 @@ class DatabaseDriver extends ServiceDriver
         }
 
         return $merchant;
+    }
+
+    /**
+     * Get the default merchantable identifier.
+     *
+     * @param \Payavel\Orchestration\Contracts\Providable|null $provider
+     * @return string|int
+     */
+    public function getDefaultMerchant(Providable $provider = null)
+    {
+        return $this->service->default_merchant_id;
     }
 
     /**

--- a/src/Models/Merchant.php
+++ b/src/Models/Merchant.php
@@ -74,7 +74,7 @@ class Merchant extends Model implements Merchantable
      */
     public function providers()
     {
-        return $this->belongsToMany($this->getProviderModelClass(), 'merchant_provider', 'merchant_id', 'provider_id')->withPivot(['default'])->withTimestamps();
+        return $this->belongsToMany($this->getProviderModelClass(), 'merchant_provider', 'merchant_id', 'provider_id')->withTimestamps();
     }
 
     /**

--- a/src/Models/Provider.php
+++ b/src/Models/Provider.php
@@ -74,7 +74,7 @@ class Provider extends Model implements Providable
      */
     public function merchants()
     {
-        return $this->belongsToMany($this->getMerchantModelClass(), 'merchant_provider', 'provider_id', 'merchant_id')->withPivot(['default'])->withTimestamps();
+        return $this->belongsToMany($this->getMerchantModelClass(), 'merchant_provider', 'provider_id', 'merchant_id')->withTimestamps();
     }
 
     /**

--- a/src/Service.php
+++ b/src/Service.php
@@ -231,9 +231,9 @@ class Service
      */
     public function reset()
     {
-        $this->provider = null;
-        $this->merchant = null;
-        $this->gateway = null;
+        $this->driver->refresh();
+
+        $this->gateway = $this->merchant = $this->provider = null;
     }
 
     /**

--- a/src/ServiceDriver.php
+++ b/src/ServiceDriver.php
@@ -26,7 +26,18 @@ abstract class ServiceDriver
      */
     public function __construct(Serviceable $service)
     {
-        $this->service = $service;
+        $this->service = $this->resolveService($service);
+    }
+
+    /**
+     * Resolve the serviceable instance.
+     *
+     * @param \Payavel\Orchestration\Contracts\Serviceable $service
+     * @return \Payavel\Orchestration\Contracts\Serviceable
+     */
+    public function resolveService(Serviceable $service)
+    {
+        return $service;
     }
 
     /**
@@ -43,10 +54,7 @@ abstract class ServiceDriver
      * @param \Payavel\Orchestration\Contracts\Merchantable|null $merchant
      * @return string|int
      */
-    public function getDefaultProvider(Merchantable $merchant = null)
-    {
-        return $this->config($this->service->getId(), 'defaults.provider');
-    }
+    abstract public function getDefaultProvider(Merchantable $merchant = null);
 
     /**
      * Resolve the merchantable instance.
@@ -62,10 +70,7 @@ abstract class ServiceDriver
      * @param \Payavel\Orchestration\Contracts\Providable|null $provider
      * @return string|int
      */
-    public function getDefaultMerchant(Providable $provider = null)
-    {
-        return $this->config($this->service->getId(), 'defaults.merchant');
-    }
+    abstract public function getDefaultMerchant(Providable $provider = null);
 
     /**
      * Verify that the merchant is compatible with the provider.

--- a/src/ServiceDriver.php
+++ b/src/ServiceDriver.php
@@ -41,6 +41,16 @@ abstract class ServiceDriver
     }
 
     /**
+     * Refresh the driver's properties if necessary.
+     *
+     * @return void
+     */
+    public function refresh()
+    {
+        //
+    }
+
+    /**
      * Resolve the providable instance.
      *
      * @param \Payavel\Orchestration\Contracts\Providable|string|int $provider

--- a/tests/Traits/CreatesServiceables.php
+++ b/tests/Traits/CreatesServiceables.php
@@ -2,10 +2,12 @@
 
 namespace Payavel\Orchestration\Tests\Traits;
 
+use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Str;
 use Payavel\Orchestration\Contracts\Merchantable;
 use Payavel\Orchestration\Contracts\Providable;
+use Payavel\Orchestration\Contracts\Serviceable;
 use Payavel\Orchestration\DataTransferObjects\Merchant as MerchantDto;
 use Payavel\Orchestration\DataTransferObjects\Provider as ProviderDto;
 use Payavel\Orchestration\DataTransferObjects\Service as ServiceDto;
@@ -39,15 +41,15 @@ trait CreatesServiceables
     }
 
     protected function createProvider($service = null, $data = [])
-{
-    if (is_null($service)) {
-        $service = $this->createService();
+    {
+        if (is_null($service)) {
+            $service = $this->createService();
+        }
+
+        $createProvider = 'createProvider' . Str::studly(Config::get('orchestration.defaults.driver'));
+
+        return $this->$createProvider($service, $data);
     }
-
-    $createProvider = 'createProvider' . Str::studly(Config::get('orchestration.defaults.driver'));
-
-    return $this->$createProvider($service, $data);
-}
 
     protected function createProviderConfig($service, $data)
     {
@@ -118,5 +120,45 @@ trait CreatesServiceables
     protected function linkMerchantToProviderDatabase(Merchantable $merchant, Providable $provider, $data)
     {
         $merchant->providers()->sync([$provider->getId() => $data], false);
+    }
+
+    protected function setDefaultsForService(Serviceable $service, Merchantable $merchant = null, Providable $provider = null)
+    {
+        $setDefaultsForService = 'setDefaultsForService' . Str::studly(Config::get('orchestration.defaults.driver'));
+
+        $this->$setDefaultsForService($service, $merchant, $provider);
+    }
+
+    protected function setDefaultsForServiceConfig(Serviceable $service, Merchantable $merchant = null, Providable $provider = null)
+    {
+        Config::set(
+            Str::slug($service->getId()) . '.defaults.merchant',
+            $merchant instanceof Merchantable ? $merchant->getId() : $merchant
+        );
+
+        if (is_null($provider) && ! is_null($merchant)) {
+            $provider = Collection::make(
+                Config::get(Str::slug($service->getId()) . '.merchants.' . $merchant->getId() . '.providers')
+            )
+                ->keys()
+                ->first();
+        }
+
+        Config::set(
+            Str::slug($service->getId()) . '.defaults.provider',
+            $provider instanceof Providable ? $provider->getId() : $provider
+        );
+    }
+
+    protected function setDefaultsForServiceDatabase(Serviceable $service, Merchantable $merchant = null, Providable $provider = null)
+    {
+        if (is_null($provider) && ! is_null($merchant)) {
+            $provider = $merchant->default_provider_id;
+        }
+
+        $service->update([
+            'default_merchant_id' => $merchant instanceof Merchantable ? $merchant->getId() : $merchant,
+            'default_provider_id' => $provider instanceof  Providable ? $provider->getId() : $provider,
+        ]);
     }
 }

--- a/tests/Unit/TestService.php
+++ b/tests/Unit/TestService.php
@@ -48,6 +48,7 @@ class TestService extends TestCase
 
         $this->setDefaultsForService($this->serviceable, $this->merchantable, $this->providable);
 
+        // ToDo: Find a place to define the test mode classes when using the database driver.
         Config::set(Str::slug($this->serviceable->getId()) . '.testing', [
             'request_class' => FakeMockRequest::class,
             'response_class' => FakeMockResponse::class,

--- a/tests/Unit/TestService.php
+++ b/tests/Unit/TestService.php
@@ -46,8 +46,8 @@ class TestService extends TestCase
 
         $this->linkMerchantToProvider($this->merchantable, $this->providable);
 
-        Config::set(Str::slug($this->serviceable->getId()) . '.defaults.provider', $this->providable->getId());
-        Config::set(Str::slug($this->serviceable->getId()) . '.defaults.merchant', $this->merchantable->getId());
+        $this->setDefaultsForService($this->serviceable, $this->merchantable, $this->providable);
+
         Config::set(Str::slug($this->serviceable->getId()) . '.testing', [
             'request_class' => FakeMockRequest::class,
             'response_class' => FakeMockResponse::class,


### PR DESCRIPTION
### **What does this PR do?** :robot:
Fixes various issues with the way the databased driver had to rely on config to resolve some of it's dependencies:
- It was unable to find the default provider & merchant based on the service.
- There was a column name mismatch with the code in the `merchant_provider.default` (changed to `is_default`).
- The way it was looking for default provider for a specific merchant was not the most optimal (within the many to many relationship).

### **How should this be tested?** :microscope:
Provide all the details on how this should be tested step by step.

### **Any background context you would like to provide?** :construction:
Provide any other information that the reviewer and/or tester should know.

### **Any questions or suggestions?** :thought_balloon:
Provide any questions or suggestions you might have about this change or future changes.

### **Does this relate to any issue?** :link:
Closes #30 
