### PR TITLE
:construction: [1.0] Find test_mode gateway without relying on config when using database driver.

### DIFF
--- a/database/factories/ProviderFactory.php
+++ b/database/factories/ProviderFactory.php
@@ -50,7 +50,7 @@ class ProviderFactory extends Factory
             $studlyService = Str::studly($provider->service_id);
 
             if (is_null($provider->gateway)) {
-                $provider->gateway = "\App\Services\{$studlyService}\{$studlyProvider}{$studlyService}Request";
+                $provider->gateway = "\\App\\Services\\{$studlyService}\\{$studlyProvider}{$studlyService}Request";
             }
         });
     }

--- a/database/factories/ProviderFactory.php
+++ b/database/factories/ProviderFactory.php
@@ -52,10 +52,6 @@ class ProviderFactory extends Factory
             if (is_null($provider->request_class)) {
                 $provider->request_class = "\App\Services\{$studlyService}\{$studlyProvider}{$studlyService}Request";
             }
-
-            if (is_null($provider->response_class)) {
-                $provider->response_class = "\App\Services\{$studlyService}\{$studlyProvider}{$studlyService}Response";
-            }
         });
     }
 }

--- a/database/factories/ProviderFactory.php
+++ b/database/factories/ProviderFactory.php
@@ -49,8 +49,8 @@ class ProviderFactory extends Factory
             $studlyProvider = Str::studly($provider->id);
             $studlyService = Str::studly($provider->service_id);
 
-            if (is_null($provider->request_class)) {
-                $provider->request_class = "\App\Services\{$studlyService}\{$studlyProvider}{$studlyService}Request";
+            if (is_null($provider->gateway)) {
+                $provider->gateway = "\App\Services\{$studlyService}\{$studlyProvider}{$studlyService}Request";
             }
         });
     }

--- a/database/factories/ServiceFactory.php
+++ b/database/factories/ServiceFactory.php
@@ -22,10 +22,26 @@ class ServiceFactory extends Factory
      */
     public function definition()
     {
-        $service = $this->faker->unique()->word();
-
         return [
-            'id' => Str::lower($service),
+            'id' => Str::lower($this->faker->unique()->word()),
         ];
+    }
+
+    /**
+     * Configure the model factory.
+     *
+     * @return $this
+     */
+    public function configure()
+    {
+        return $this->afterMaking(function (Service $service) {
+            if (! is_null($service->test_gateway)) {
+                return;
+            }
+
+            $studlyService = Str::studly($service->id);
+
+            $service->test_gateway = "\App\Services\{$studlyService}\Fake{$studlyService}Request";
+        });
     }
 }

--- a/database/factories/ServiceFactory.php
+++ b/database/factories/ServiceFactory.php
@@ -41,7 +41,7 @@ class ServiceFactory extends Factory
 
             $studlyService = Str::studly($service->id);
 
-            $service->test_gateway = "\App\Services\{$studlyService}\Fake{$studlyService}Request";
+            $service->test_gateway = "\\App\\Services\\{$studlyService}\\Fake{$studlyService}Request";
         });
     }
 }

--- a/database/migrations/0001_01_01_000001_create_base_orchestration_tables.php
+++ b/database/migrations/0001_01_01_000001_create_base_orchestration_tables.php
@@ -30,7 +30,7 @@ class CreateBaseOrchestrationTables extends Migration
             Schema::create('providers', function (Blueprint $table) {
                 $table->string('id')->primary();
                 $table->string('service_id');
-                $table->string('request_class');
+                $table->string('gateway');
                 $table->timestamps();
 
                 $table->foreign('service_id')->references('id')->on('services')->onUpdate('cascade')->onDelete('cascade');

--- a/database/migrations/0001_01_01_000001_create_base_orchestration_tables.php
+++ b/database/migrations/0001_01_01_000001_create_base_orchestration_tables.php
@@ -31,7 +31,6 @@ class CreateBaseOrchestrationTables extends Migration
                 $table->string('id')->primary();
                 $table->string('service_id');
                 $table->string('request_class');
-                $table->string('response_class');
                 $table->timestamps();
 
                 $table->foreign('service_id')->references('id')->on('services')->onUpdate('cascade')->onDelete('cascade');

--- a/database/migrations/0001_01_01_000001_create_base_orchestration_tables.php
+++ b/database/migrations/0001_01_01_000001_create_base_orchestration_tables.php
@@ -21,6 +21,7 @@ class CreateBaseOrchestrationTables extends Migration
                 $table->string('id')->primary();
                 $table->string('default_provider_id')->nullable();
                 $table->string('default_merchant_id')->nullable();
+                $table->string('test_gateway')->nullable();
                 $table->timestamps();
 
                 $table->foreign('default_provider_id')->references('id')->on('providers')->onUpdate('cascade')->onDelete('set null');

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -201,7 +201,6 @@ return [
 
     'testing' => [
         'request_class' => \App\Services\Checkout\FakeCheckoutRequest::class,
-        'response_class' => \App\Services\Checkout\FakeCheckoutResponse::class,
     ],
 
 ];
@@ -217,12 +216,10 @@ return [
     
         'adyen' => [
             'request_class' => \App\Services\Checkout\AdyenCheckoutRequest::class,
-            'response_class' => \App\Services\Checkout\AdyenCheckoutResponse::class,
         ],
         
         'stripe' => [
             'request_class' => \App\Services\Checkout\StripeCheckoutRequest::class,
-            'response_class' => \App\Services\Checkout\StripeCheckoutResponse::class,
         ],
         
     ],

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -200,7 +200,7 @@ Here you should register the service's fake classes that will mock your provider
 return [
 
     'testing' => [
-        'request_class' => \App\Services\Checkout\FakeCheckoutRequest::class,
+        'gateway' => \App\Services\Checkout\FakeCheckoutRequest::class,
     ],
 
 ];
@@ -215,11 +215,11 @@ return [
     'providers' => [
     
         'adyen' => [
-            'request_class' => \App\Services\Checkout\AdyenCheckoutRequest::class,
+            'gateway' => \App\Services\Checkout\AdyenCheckoutRequest::class,
         ],
         
         'stripe' => [
-            'request_class' => \App\Services\Checkout\StripeCheckoutRequest::class,
+            'gateway' => \App\Services\Checkout\StripeCheckoutRequest::class,
         ],
         
     ],

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -195,13 +195,11 @@ return [
 ```
 
 ### Testing
-Here you should register the service's fake classes that will mock your provider's response when in test mode.
+Here you should register the service's fake gateway that will mock your provider's response when in test mode.
 ```php
 return [
 
-    'testing' => [
-        'gateway' => \App\Services\Checkout\FakeCheckoutRequest::class,
-    ],
+    'test_gateway' => \App\Services\Checkout\FakeCheckoutRequest::class,
 
 ];
 ```

--- a/src/Drivers/ConfigDriver.php
+++ b/src/Drivers/ConfigDriver.php
@@ -147,7 +147,7 @@ class ConfigDriver extends ServiceDriver
      */
     public function resolveGatewayClass($provider)
     {
-        return $provider->request_class;
+        return $provider->gateway;
     }
 
     /**

--- a/src/Drivers/ConfigDriver.php
+++ b/src/Drivers/ConfigDriver.php
@@ -137,7 +137,7 @@ class ConfigDriver extends ServiceDriver
      * 
      * @throws Exception
      */
-    public function check($provider, $merchant)
+    protected function check($provider, $merchant)
     {
         if ($merchant->providers->contains('id', $provider->id)) {
             return;

--- a/src/Drivers/DatabaseDriver.php
+++ b/src/Drivers/DatabaseDriver.php
@@ -2,6 +2,7 @@
 
 namespace Payavel\Orchestration\Drivers;
 
+use Exception;
 use Payavel\Orchestration\Contracts\Merchantable;
 use Payavel\Orchestration\Contracts\Providable;
 use Payavel\Orchestration\Contracts\Serviceable;
@@ -110,26 +111,45 @@ class DatabaseDriver extends ServiceDriver
      *
      * @param \Payavel\Orchestration\Contracts\Providable
      * @param \Payavel\Orchestration\Contracts\Merchantable
-     * @return bool
+     * @return void
+     * 
+     * @throws Exception
      */
     public function check($provider, $merchant)
     {
-        if (! $merchant->providers->contains($provider)) {
-            return false;
+        if ($merchant->providers->contains($provider)) {
+            return;
         }
 
-        return true;
+        throw new Exception("The {$merchant->getName()} merchant is not supported by the {$provider->getName()} provider.");
     }
 
     /**
-     * Resolve the gateway class.
+     * Resolve the gateway.
      *
      * @param \Payavel\Orchestration\Contracts\Providable $provider
-     * @return string
+     * @param \Payavel\Orchestration\Contracts\Merchantable $merchant
+     * @return \Payavel\Orchestration\ServiceRequest
+     * 
+     * @throws Exception
      */
-    public function resolveGatewayClass($provider)
+    public function resolveGateway($provider, $merchant)
     {
-        return $provider->gateway;
+        $this->check($provider, $merchant);
+
+        $gateway = $this->config($this->service->getId(), 'test_mode')
+            ? $this->service->test_gateway
+            : $provider->gateway;
+
+        if (! class_exists($gateway)) {
+            throw new Exception(
+                is_null($gateway)
+                    ? "You must set a gateway for the {$provider->getName()} {$this->service->getName()} provider."
+                    : "The {$gateway}::class does not exist."
+            );
+        }
+
+        return new $gateway($provider, $merchant);
     }
 
     /**

--- a/src/Drivers/DatabaseDriver.php
+++ b/src/Drivers/DatabaseDriver.php
@@ -115,7 +115,7 @@ class DatabaseDriver extends ServiceDriver
      * 
      * @throws Exception
      */
-    public function check($provider, $merchant)
+    protected function check($provider, $merchant)
     {
         if ($merchant->providers->contains($provider)) {
             return;

--- a/src/Drivers/DatabaseDriver.php
+++ b/src/Drivers/DatabaseDriver.php
@@ -129,7 +129,7 @@ class DatabaseDriver extends ServiceDriver
      */
     public function resolveGatewayClass($provider)
     {
-        return $provider->request_class;
+        return $provider->gateway;
     }
 
     /**

--- a/src/Service.php
+++ b/src/Service.php
@@ -197,31 +197,13 @@ class Service
      * Instantiate a new instance of the serviceable gateway.
      *
      * @return void
-     *
-     * @throws Exception
      */
     protected function setGateway()
     {
         $provider = $this->getProvider();
         $merchant = $this->getMerchant();
 
-        if (! $this->driver->check($provider, $merchant)) {
-            throw new Exception("The {$merchant->getName()} merchant is not supported by the {$provider->getName()} provider.");
-        }
-
-        $gateway = $this->config($this->service->getId(), 'test_mode')
-            ? $this->config($this->service->getId(), 'testing.gateway')
-            : $this->driver->resolveGatewayClass($provider);
-
-        if (! class_exists($gateway)) {
-            throw new Exception(
-                is_null($gateway)
-                    ? "You must set a gateway for the {$provider->getName()} {$this->service->getName()} provider."
-                    : "The {$gateway}::class does not exist."
-            );
-        }
-
-        $this->gateway = new $gateway($provider, $merchant);
+        $this->gateway = $this->driver->resolveGateway($provider, $merchant);
     }
 
     /**

--- a/src/Service.php
+++ b/src/Service.php
@@ -210,13 +210,13 @@ class Service
         }
 
         $gateway = $this->config($this->service->getId(), 'test_mode')
-            ? $this->config($this->service->getId(), 'testing.request_class')
+            ? $this->config($this->service->getId(), 'testing.gateway')
             : $this->driver->resolveGatewayClass($provider);
 
         if (! class_exists($gateway)) {
             throw new Exception(
                 is_null($gateway)
-                    ? "You must set a request_class for the {$provider->getName()} {$this->service->getName()} provider."
+                    ? "You must set a gateway for the {$provider->getName()} {$this->service->getName()} provider."
                     : "The {$gateway}::class does not exist."
             );
         }

--- a/src/ServiceDriver.php
+++ b/src/ServiceDriver.php
@@ -92,12 +92,13 @@ abstract class ServiceDriver
     abstract public function check($provider, $merchant);
 
     /**
-     * Resolve the gateway class.
+     * Resolve the gateway.
      *
      * @param \Payavel\Orchestration\Contracts\Providable $provider
-     * @return string
+     * @param \Payavel\Orchestration\Contracts\Merchantable $merchant
+     * @return \Payavel\Orchestration\ServiceRequest
      */
-    abstract public function resolveGatewayClass($provider);
+    abstract public function resolveGateway($provider, $merchant);
 
     /**
      * Get a collection of existing serviceables.

--- a/src/ServiceDriver.php
+++ b/src/ServiceDriver.php
@@ -83,15 +83,6 @@ abstract class ServiceDriver
     abstract public function getDefaultMerchant(Providable $provider = null);
 
     /**
-     * Verify that the merchant is compatible with the provider.
-     *
-     * @param \Payavel\Orchestration\Contracts\Providable
-     * @param \Payavel\Orchestration\Contracts\Merchantable
-     * @return bool
-     */
-    abstract public function check($provider, $merchant);
-
-    /**
      * Resolve the gateway.
      *
      * @param \Payavel\Orchestration\Contracts\Providable $provider

--- a/stubs/config-service-provider.stub
+++ b/stubs/config-service-provider.stub
@@ -1,5 +1,4 @@
 
         '{{ id }}' => [
             'request_class' => \App\Services\{{ Service }}\{{ Provider }}{{ Service }}Request::class,
-            'response_class' => \App\Services\{{ Service }}\{{ Provider }}{{ Service }}Response::class,
         ],

--- a/stubs/config-service-provider.stub
+++ b/stubs/config-service-provider.stub
@@ -1,4 +1,4 @@
 
         '{{ id }}' => [
-            'request_class' => \App\Services\{{ Service }}\{{ Provider }}{{ Service }}Request::class,
+            'gateway' => \App\Services\{{ Service }}\{{ Provider }}{{ Service }}Request::class,
         ],

--- a/stubs/config-service.stub
+++ b/stubs/config-service.stub
@@ -41,7 +41,6 @@ return [
     */
     'testing' => [
         'request_class' => \App\Services\{{ Service }}\Fake{{ Service }}Request::class,
-        'response_class' => \App\Services\{{ Service }}\Fake{{ Service }}Response::class,
     ],
 
     /*

--- a/stubs/config-service.stub
+++ b/stubs/config-service.stub
@@ -39,9 +39,7 @@ return [
     | is set to true. Also, feel free to add any other settings here.
     |
     */
-    'testing' => [
-        'gateway' => \App\Services\{{ Service }}\Fake{{ Service }}Request::class,
-    ],
+    'test_gateway' => \App\Services\{{ Service }}\Fake{{ Service }}Request::class,
 
     /*
     |--------------------------------------------------------------------------

--- a/stubs/config-service.stub
+++ b/stubs/config-service.stub
@@ -40,7 +40,7 @@ return [
     |
     */
     'testing' => [
-        'request_class' => \App\Services\{{ Service }}\Fake{{ Service }}Request::class,
+        'gateway' => \App\Services\{{ Service }}\Fake{{ Service }}Request::class,
     ],
 
     /*

--- a/tests/Traits/CreatesServiceables.php
+++ b/tests/Traits/CreatesServiceables.php
@@ -27,12 +27,15 @@ trait CreatesServiceables
     protected function createServiceConfig($data)
     {
         $data['id'] = $data['id'] ?? Str::lower($this->faker->unique()->word());
+        $data['test_gateway'] = $data['test_gateway'] ?? '\\App\\Services\\' . Str::studly($data['id']) . '\\Fake' . Str::studly($data['id']) . 'Request';
 
         Config::set('orchestration.services.' . $data['id'], [
-            'config' => Str::slug($data['id']),
+            'config' => $serviceSlug = Str::slug($data['id']),
         ]);
 
-        return new ServiceDto($data);;
+        Config::set($serviceSlug . '.testing.gateway', $data['test_gateway']);
+
+        return new ServiceDto($data);
     }
 
     protected function createServiceDatabase($data)

--- a/tests/Traits/CreatesServiceables.php
+++ b/tests/Traits/CreatesServiceables.php
@@ -55,11 +55,9 @@ trait CreatesServiceables
     {
         $data['id'] = $data['id'] ?? preg_replace('/[^a-z0-9]+/i', '_', strtolower(Str::remove(['\'', ','], $this->faker->unique()->company())));
         $data['request_class'] = $data['request_class'] ?? 'App\\Services\\' . Str::studly($service->getId()) . '\\' . Str::studly($data['id']) . Str::studly($service->getId()) . 'Request';
-        $data['response_class'] = $data['response_class'] ?? 'App\\Services\\' . Str::studly($service->getId()) . '\\' . Str::studly($data['id']) . Str::studly($service->getId()) . 'Response';
 
         Config::set(Str::slug($service->getId()) . '.providers.' . $data['id'], [
             'request_class' => $data['request_class'],
-            'response_class' => $data['response_class'],
         ]);
 
         return new ProviderDto($service, $data);

--- a/tests/Traits/CreatesServiceables.php
+++ b/tests/Traits/CreatesServiceables.php
@@ -54,10 +54,10 @@ trait CreatesServiceables
     protected function createProviderConfig($service, $data)
     {
         $data['id'] = $data['id'] ?? preg_replace('/[^a-z0-9]+/i', '_', strtolower(Str::remove(['\'', ','], $this->faker->unique()->company())));
-        $data['request_class'] = $data['request_class'] ?? 'App\\Services\\' . Str::studly($service->getId()) . '\\' . Str::studly($data['id']) . Str::studly($service->getId()) . 'Request';
+        $data['gateway'] = $data['gateway'] ?? 'App\\Services\\' . Str::studly($service->getId()) . '\\' . Str::studly($data['id']) . Str::studly($service->getId()) . 'Request';
 
         Config::set(Str::slug($service->getId()) . '.providers.' . $data['id'], [
-            'request_class' => $data['request_class'],
+            'gateway' => $data['gateway'],
         ]);
 
         return new ProviderDto($service, $data);

--- a/tests/Unit/TestService.php
+++ b/tests/Unit/TestService.php
@@ -32,6 +32,7 @@ class TestService extends TestCase
 
         $this->serviceable = $this->createService([
             'id' => 'mock',
+            'test_gateway' => FakeMockRequest::class,
         ]);
 
         $this->providable = $this->createProvider($this->serviceable, [
@@ -46,11 +47,6 @@ class TestService extends TestCase
         $this->linkMerchantToProvider($this->merchantable, $this->providable);
 
         $this->setDefaultsForService($this->serviceable, $this->merchantable, $this->providable);
-
-        // ToDo: Find a place to define the test mode classes when using the database driver.
-        Config::set(Str::slug($this->serviceable->getId()) . '.testing', [
-            'gateway' => FakeMockRequest::class,
-        ]);
 
         $this->setMode($this->serviceable);
 

--- a/tests/Unit/TestService.php
+++ b/tests/Unit/TestService.php
@@ -37,7 +37,6 @@ class TestService extends TestCase
         $this->providable = $this->createProvider($this->serviceable, [
             'id' => 'test',
             'request_class' => TestMockRequest::class,
-            'response_class' => TestMockResponse::class,
         ]);
 
         $this->merchantable = $this->createMerchant($this->serviceable, [
@@ -51,7 +50,6 @@ class TestService extends TestCase
         // ToDo: Find a place to define the test mode classes when using the database driver.
         Config::set(Str::slug($this->serviceable->getId()) . '.testing', [
             'request_class' => FakeMockRequest::class,
-            'response_class' => FakeMockResponse::class,
         ]);
 
         $this->setMode($this->serviceable);

--- a/tests/Unit/TestService.php
+++ b/tests/Unit/TestService.php
@@ -36,7 +36,7 @@ class TestService extends TestCase
 
         $this->providable = $this->createProvider($this->serviceable, [
             'id' => 'test',
-            'request_class' => TestMockRequest::class,
+            'gateway' => TestMockRequest::class,
         ]);
 
         $this->merchantable = $this->createMerchant($this->serviceable, [
@@ -49,7 +49,7 @@ class TestService extends TestCase
 
         // ToDo: Find a place to define the test mode classes when using the database driver.
         Config::set(Str::slug($this->serviceable->getId()) . '.testing', [
-            'request_class' => FakeMockRequest::class,
+            'gateway' => FakeMockRequest::class,
         ]);
 
         $this->setMode($this->serviceable);


### PR DESCRIPTION
### **What does this PR do?** :robot:
- Removes all references to `response_class`.
- Renames `request_class` to `gateway`.
- Makes it possible to store the reference to the fake provider implementation via the database driver.

### **How should this be tested?** :microscope:
Provide all the details on how this should be tested step by step.

### **Any background context you would like to provide?** :construction:
Provide any other information that the reviewer and/or tester should know.

### **Any questions or suggestions?** :thought_balloon:
Provide any questions or suggestions you might have about this change or future changes.

### **Does this relate to any issue?** :link:
Closes #33
