### PR TITLE
[1.x] Config by value type.

### DIFF
--- a/src/Console/Commands/Install.php
+++ b/src/Console/Commands/Install.php
@@ -95,9 +95,7 @@ class Install extends Command
             );
         }
 
-        Config::set('orchestration.services.' . $this->service->getId(), [
-            'config' => Str::slug($this->service->getId()),
-        ]);
+        Config::set('orchestration.services.' . $this->service->getId(), Str::slug($this->service->getId()));
 
         $this->putFile(
             app_path("Services/{$studlyService}/Contracts/{$studlyService}Requester.php"),

--- a/src/DataTransferObjects/Service.php
+++ b/src/DataTransferObjects/Service.php
@@ -44,9 +44,11 @@ class Service implements Serviceable
      */
     public static function fromServiceable(Serviceable $service)
     {
+        $config = Config::get('orchestration.services.' . $service->getId(), []);
+
         return new static(array_merge(
             ['id' => $service->getId()],
-            Config::get('orchestration.services.' . $service->getId(), [])
+            is_array($config) ? $config : Config::get($config)
         ));
     }
 }

--- a/src/Drivers/ConfigDriver.php
+++ b/src/Drivers/ConfigDriver.php
@@ -182,7 +182,7 @@ class ConfigDriver extends ServiceDriver
     public static function services()
     {
         return collect(Config::get('orchestration.services', []))->map(
-            fn ($value, $key) => new Service(array_merge(['id' => $key], $value))
+            fn ($value, $key) => new Service(array_merge(['id' => $key], is_array($value) ? $value : Config::get($value)))
         )->values();
     }
 }

--- a/src/Traits/ServesConfig.php
+++ b/src/Traits/ServesConfig.php
@@ -17,7 +17,11 @@ trait ServesConfig
      */
     public function config($service, $key, $default = null)
     {
-        $config = Config::get('orchestration.services.' . $service . '.config', Str::slug($service));
+        $config = Config::get('orchestration.services.' . $service, Str::slug($service));
+
+        if (is_array($config)) {
+            return Config::get('orchestration.services.' . $service . '.' . $key, $default);
+        }
 
         return Config::get(
             $config .  '.' . $key,

--- a/stubs/config-orchestration.stub
+++ b/stubs/config-orchestration.stub
@@ -14,9 +14,7 @@ return [
     */
     'services' => [
 
-        '{{ id }}' => [
-            'config' => '{{ config }}',
-        ],
+        '{{ id }}' => '{{ config }}',
 
     ],
 

--- a/tests/Traits/CreatesServiceables.php
+++ b/tests/Traits/CreatesServiceables.php
@@ -29,9 +29,7 @@ trait CreatesServiceables
         $data['id'] = $data['id'] ?? Str::lower($this->faker->unique()->word());
         $data['test_gateway'] = $data['test_gateway'] ?? '\\App\\Services\\' . Str::studly($data['id']) . '\\Fake' . Str::studly($data['id']) . 'Request';
 
-        Config::set('orchestration.services.' . $data['id'], [
-            'config' => $serviceSlug = Str::slug($data['id']),
-        ]);
+        Config::set('orchestration.services.' . $data['id'], $serviceSlug = Str::slug($data['id']));
 
         Config::set($serviceSlug . '.testing.gateway', $data['test_gateway']);
 

--- a/tests/Unit/ServesConfigTraitTest.php
+++ b/tests/Unit/ServesConfigTraitTest.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Payavel\Orchestration\Tests\Unit;
+
+use Illuminate\Support\Facades\Config;
+use Payavel\Orchestration\Tests\TestCase;
+use Payavel\Orchestration\Traits\ServesConfig;
+
+class ServesConfigTraitTest extends TestCase
+{
+    use ServesConfig;
+
+    /** @test */
+    public function set_service_config_in_separate_config()
+    {
+        Config::set('orchestration.services.mock', 'mock');
+
+        Config::set('mock', [
+            'assert' => true,
+        ]);
+
+        $this->assertTrue($this->config('mock', 'assert'));
+    }
+
+    /** @test */
+    public function set_service_config_in_orchestration_config()
+    {
+        Config::set('orchestration.services.mock', [
+            'assert' => true,
+        ]);
+
+        $this->assertTrue($this->config('mock', 'assert'));
+    }
+}


### PR DESCRIPTION
### **What does this PR do?** :robot:
Allows multiple mays to specify your service config.

You may either specify a string value pointing to another config file, or define your config in an array withing your orchestration config.

### **Any background context you would like to provide?** :construction:
The reasoning behind this is when you utilize the database driver, having a separate config file for that service is unnecessary.

### **Does this relate to any issue?** :link:
Closes #36.
