### PR TITLE
[1.x] Rename `getStatus` & `getMessage` methods.

### DIFF
--- a/src/ServiceResponse.php
+++ b/src/ServiceResponse.php
@@ -157,14 +157,14 @@ abstract class ServiceResponse
      *
      * @return string|null
      */
-    public abstract function getStatus();
+    public abstract function getStatusMessage();
 
     /**
      * Get a description of the response's status.
      *
      * @return string|null
      */
-    public abstract function getMessage();
+    public abstract function getStatusDescription();
 
     /**
      * Get the formatted details based on the request that was made.

--- a/stubs/service-response.stub
+++ b/stubs/service-response.stub
@@ -32,7 +32,7 @@ class {{ Provider }}{{ Service }}Response extends ServiceResponse implements {{ 
      *
      * @return string|null
      */
-    public function getStatus()
+    public function getStatusMessage()
     {
         //
     }
@@ -42,7 +42,7 @@ class {{ Provider }}{{ Service }}Response extends ServiceResponse implements {{ 
      *
      * @return string|null
      */
-    public function getMessage()
+    public function getStatusDescription()
     {
         //
     }

--- a/tests/Services/Mock/FakeMockResponse.php
+++ b/tests/Services/Mock/FakeMockResponse.php
@@ -19,7 +19,7 @@ class FakeMockResponse extends ServiceResponse implements MockResponder
     /**
      * @inheritDoc
      */
-    public function getStatus()
+    public function getStatusMessage()
     {
         return 'Success';
     }
@@ -27,7 +27,7 @@ class FakeMockResponse extends ServiceResponse implements MockResponder
     /**
      * @inheritDoc
      */
-    public function getMessage()
+    public function getStatusDescription()
     {
         return 'All good for now!';
     }

--- a/tests/Services/Mock/TestMockResponse.php
+++ b/tests/Services/Mock/TestMockResponse.php
@@ -19,7 +19,7 @@ class TestMockResponse extends ServiceResponse implements MockResponder
     /**
      * @inheritDoc
      */
-    public function getStatus()
+    public function getStatusMessage()
     {
         return 'Success';
     }
@@ -27,7 +27,7 @@ class TestMockResponse extends ServiceResponse implements MockResponder
     /**
      * @inheritDoc
      */
-    public function getMessage()
+    public function getStatusDescription()
     {
         return 'All good for now!';
     }


### PR DESCRIPTION
### **What does this PR do?** :robot:
Renames the `ServiceResponse::class` abstract methods `getStatus` & `getMessage` to `getStatusMessage` & `getStatusDescription` respectively.

### **Does this relate to any issue?** :link:
Closes #26 
