### PR TITLE
[1.x] Fix error when calling the `orchestrate:provider` command after generating service via the `orchestrate:service` command.

### DIFF
--- a/src/Console/Commands/OrchestrateService.php
+++ b/src/Console/Commands/OrchestrateService.php
@@ -136,6 +136,8 @@ class OrchestrateService extends Command
      */
     protected function generateProviders()
     {
+        $this->callSilently('config:cache');
+
         $this->call("orchestrate:provider", ['--service' => $this->service->getId(), '--fake' => true]);
 
         $this->providers->each(

--- a/src/Console/Commands/OrchestrateService.php
+++ b/src/Console/Commands/OrchestrateService.php
@@ -136,7 +136,7 @@ class OrchestrateService extends Command
      */
     protected function generateProviders()
     {
-        $this->callSilently('config:cache');
+        $this->callSilently('config:clear');
 
         $this->call("orchestrate:provider", ['--service' => $this->service->getId(), '--fake' => true]);
 


### PR DESCRIPTION
### **What does this PR do?** :robot:
It clears the config silently after orchestrating a new service, for the `orchestrate:provider` command to function properly.

