### PR TITLE
[1.x] Abstract gateway response.

### DIFF
--- a/src/Service.php
+++ b/src/Service.php
@@ -230,11 +230,7 @@ class Service
      */
     public function __call($method, $params)
     {
-        if (! method_exists($this->getGateway(), $method)) {
-            throw new \BadMethodCallException(__CLASS__ . "::{$method}() not found.");
-        }
-
-        return tap($this->gateway->{$method}(...$params))->configure($method, $this->provider, $this->merchant);
+        return $this->getGateway()->request($method, $params);
     }
 
     /**

--- a/src/ServiceRequest.php
+++ b/src/ServiceRequest.php
@@ -85,7 +85,7 @@ abstract class ServiceRequest
      */
     public function response($rawResponse)
     {
-        $serviceResponse = $this->serviceResponse ?? Str::replace('Request', 'Response', self::class);
+        $serviceResponse = $this->serviceResponse ?? Str::replace('Request', 'Response', get_class($this));
 
         return new $serviceResponse($rawResponse);
     }

--- a/src/ServiceRequest.php
+++ b/src/ServiceRequest.php
@@ -4,9 +4,17 @@ namespace Payavel\Orchestration;
 
 use Payavel\Orchestration\Contracts\Merchantable;
 use Payavel\Orchestration\Contracts\Providable;
+use Illuminate\Support\Str;
 
 abstract class ServiceRequest
 {
+    /**
+     * The service response class.
+     *
+     * @var \Payavel\Orchestration\ServiceResponse
+     */
+    protected $serviceResponse;
+
     /**
      * The service provider.
      *
@@ -41,5 +49,44 @@ abstract class ServiceRequest
     protected function setUp()
     {
         //
+    }
+
+    /**
+     * Make the request.
+     *
+     * @param string $method
+     * @param array|null $params
+     *
+     * @return \Payavel\Orchestration\ServiceResponse|mixed
+     *
+     * @throws \BadMethodCallException
+     */
+    public function request($method, $params)
+    {
+        if (! method_exists($this, $method)) {
+            throw new \BadMethodCallException(get_class($this) . "::{$method}() not found.");
+        }
+
+        $response = $this->{$method}(...$params);
+
+        if (! $response instanceof ServiceResponse) {
+            $response = $this->response($response);
+        }
+
+        return $response->configure($method, $this->provider, $this->merchant);
+    }
+
+    /**
+     * Format the response.
+     *
+     * @param mixed $rawResponse
+     *
+     * @return \Payavel\Orchestration\ServiceResponse
+     */
+    public function response($rawResponse)
+    {
+        $serviceResponse = $this->serviceResponse ?? Str::replace('Request', 'Response', self::class);
+
+        return new $serviceResponse($rawResponse);
     }
 }

--- a/src/ServiceResponse.php
+++ b/src/ServiceResponse.php
@@ -7,6 +7,8 @@ use Payavel\Orchestration\Contracts\Providable;
 use Payavel\Orchestration\Traits\SimulatesAttributes;
 use Payavel\Orchestration\Traits\ThrowsRuntimeException;
 
+use function PHPUnit\Framework\isEmpty;
+
 abstract class ServiceResponse
 {
     use SimulatesAttributes;
@@ -70,7 +72,8 @@ abstract class ServiceResponse
 
     /**
      * @param mixed $rawResponse
-     * @param mixed $additionalInformation
+     * @param mixed|null $additionalInformation
+     * @deprecated $additonalInformation will be removed, use with() instead.
      */
     public function __construct($rawResponse, $additionalInformation = null)
     {
@@ -91,18 +94,35 @@ abstract class ServiceResponse
     }
 
     /**
+     * Share additional information.
+     *
+     * @param mixed $additionalInformation
+     *
+     * @return static
+     */
+    public function with($additionalInformation)
+    {
+        $this->additionalInformation = $additionalInformation;
+
+        return $this;
+    }
+
+    /**
      * Configure the response based on the request.
      *
      * @param string $requestMethod
      * @param \Payavel\Orchestration\Contracts\Providable $provider
      * @param \Payavel\Orchestration\Contracts\Merchantable $merchant
-     * @return void
+     *
+     * @return static
      */
     public function configure(string $requestMethod, Providable $provider, Merchantable $merchant)
     {
         $this->requestMethod = $requestMethod;
         $this->provider = $provider;
         $this->merchant = $merchant;
+
+        return $this;
     }
 
     /**

--- a/tests/Services/Mock/FakeMockRequest.php
+++ b/tests/Services/Mock/FakeMockRequest.php
@@ -9,6 +9,6 @@ class FakeMockRequest extends ServiceRequest implements MockRequester
 {
     public function getIdentity()
     {
-        return new FakeMockResponse([]);
+        return [];
     }
 }

--- a/tests/Services/Mock/FakeMockRequest.php
+++ b/tests/Services/Mock/FakeMockRequest.php
@@ -7,8 +7,14 @@ use Payavel\Orchestration\Tests\Services\Mock\Contracts\MockRequester;
 
 class FakeMockRequest extends ServiceRequest implements MockRequester
 {
-    public function getIdentity()
+    public function getIdentity($withAdditionalInformation = false)
     {
-        return [];
+        $response = [];
+
+        if ($withAdditionalInformation) {
+            $response = $this->response($response)->with('additional information');
+        }
+
+        return $response;
     }
 }

--- a/tests/Services/Mock/FakeMockResponse.php
+++ b/tests/Services/Mock/FakeMockResponse.php
@@ -33,6 +33,6 @@ class FakeMockResponse extends ServiceResponse implements MockResponder
 
     public function getIdentityResponse()
     {
-        return 'Fake';
+        return 'Fake' . (is_null($this->additionalInformation) ? '' : ' with ' . $this->additionalInformation);
     }
 }

--- a/tests/Services/Mock/TestMockRequest.php
+++ b/tests/Services/Mock/TestMockRequest.php
@@ -7,8 +7,14 @@ use Payavel\Orchestration\Tests\Services\Mock\Contracts\MockRequester;
 
 class TestMockRequest extends ServiceRequest implements MockRequester
 {
-    public function getIdentity()
+    public function getIdentity($withAdditionalInformation = false)
     {
-        return [];
+        $response = [];
+
+        if ($withAdditionalInformation) {
+            $response = $this->response($response)->with('additional information');
+        }
+
+        return $response;
     }
 }

--- a/tests/Services/Mock/TestMockRequest.php
+++ b/tests/Services/Mock/TestMockRequest.php
@@ -9,6 +9,6 @@ class TestMockRequest extends ServiceRequest implements MockRequester
 {
     public function getIdentity()
     {
-        return new TestMockResponse([]);
+        return [];
     }
 }

--- a/tests/Services/Mock/TestMockResponse.php
+++ b/tests/Services/Mock/TestMockResponse.php
@@ -33,6 +33,6 @@ class TestMockResponse extends ServiceResponse implements MockResponder
 
     public function getIdentityResponse()
     {
-        return 'Real';
+        return 'Real' . (is_null($this->additionalInformation) ? '' : ' with ' . $this->additionalInformation);
     }
 }

--- a/tests/Unit/TestService.php
+++ b/tests/Unit/TestService.php
@@ -159,6 +159,16 @@ abstract class TestService extends TestCase implements CreatesServiceables
         });
     }
 
+    /** @test */
+    public function passing_additional_information_to_service_response()
+    {
+        $this->assertRealIsAlignedWithFake(function () {
+            $response = $this->service->getIdentity(true);
+
+            $this->assertStringEndsWith('additional information', $response->data);
+        });
+    }
+
     protected function assertResponseIsConfigured(ServiceResponse $response)
     {
         $this->assertEquals($this->providable->getId(), $response->provider->getId());

--- a/tests/Unit/TestService.php
+++ b/tests/Unit/TestService.php
@@ -2,6 +2,7 @@
 
 namespace Payavel\Orchestration\Tests\Unit;
 
+use BadMethodCallException;
 use Exception;
 use Payavel\Orchestration\Service;
 use Payavel\Orchestration\ServiceResponse;
@@ -142,6 +143,19 @@ abstract class TestService extends TestCase implements CreatesServiceables
             $this->service->reset();
 
             $this->assertEquals($this->merchantable->getId(), $this->service->getIdentity()->merchant->getId());
+        });
+    }
+
+    /** @test */
+    public function calling_undefined_method_on_service_throws_bad_method_call_exception()
+    {
+        $undefinedMethod = 'undefined';
+
+        $this->assertRealIsAlignedWithFake(function () use ($undefinedMethod) {
+            $this->expectException(BadMethodCallException::class);
+            $this->expectExceptionMessage(get_class($this->service->gateway) . "::{$undefinedMethod}() not found.");
+
+            $this->service->{$undefinedMethod}();
         });
     }
 


### PR DESCRIPTION
### **What does this PR do?** :robot:
- You may now return the raw response from your method instead of constructing the actual response object.
    -  It will check whether the response object was returned, if not, it will construct and configure  it using the raw response.
- Deprecates the `$additionalInformation` parameter on the response class constuctor.
    - You may use `->with()` instead to pass any `$additionalInformation` instead. 

### **Any background context you would like to provide?** :construction:
All the changes are backwards compatible, breaking change will be introduced in `2.0` to remove the `$additionalInformation` parameter.

### **Does this relate to any issue?** :link:
Closes #50 
