### PR TITLE
[2.x] Update service stub override capabilities.

### DIFF
--- a/src/Console/Commands/OrchestrateService.php
+++ b/src/Console/Commands/OrchestrateService.php
@@ -113,7 +113,7 @@ class OrchestrateService extends Command
         static::putFile(
             app_path($requesterPath = "Services/{$studlyService}/Contracts/{$studlyService}Requester.php"),
             static::makeFile(
-                static::getStub('service-requester'),
+                static::getStub('service-requester', $this->service->getId()),
                 [
                     'Service' => $studlyService,
                 ]
@@ -125,7 +125,7 @@ class OrchestrateService extends Command
         static::putFile(
             app_path($responderPath = "Services/{$studlyService}/Contracts/{$studlyService}Responder.php"),
             static::makeFile(
-                static::getStub('service-responder'),
+                static::getStub('service-responder', $this->service->getId()),
                 [
                     'Service' => $studlyService,
                 ]

--- a/src/Drivers/ConfigDriver.php
+++ b/src/Drivers/ConfigDriver.php
@@ -183,7 +183,7 @@ class ConfigDriver extends ServiceDriver
             fn ($config, $provider) =>
                 $config .
                 static::makeFile(
-                    static::getStub('config-service-provider'),
+                    static::getStub('config-service-provider', $service->getId()),
                     [
                         'id' => $provider['id'],
                         'name' => $provider['name'],
@@ -196,7 +196,7 @@ class ConfigDriver extends ServiceDriver
         $config['accounts'] = $accounts->reduce(
             fn ($config, $account) =>
                 $config . static::makeFile(
-                    static::getStub('config-service-account'),
+                    static::getStub('config-service-account', $service->getId()),
                     [
                         'id' => $account['id'],
                         'name' => $account['name'],
@@ -204,7 +204,7 @@ class ConfigDriver extends ServiceDriver
                             fn ($config, $provider, $index) =>
                                 $config .
                                 static::makeFile(
-                                    static::getStub('config-service-account-providers'),
+                                    static::getStub('config-service-account-providers', $service->getId()),
                                     ['id' => $provider]
                                 ) .
                                 ($index < count($providers) - 1 ? "\n" : ""),
@@ -218,7 +218,7 @@ class ConfigDriver extends ServiceDriver
         static::putFile(
             config_path($configPath = Str::slug($service->getId()) . '.php'),
             static::makeFile(
-                static::getStub('config-service'),
+                static::getStub('config-service', $service->getId()),
                 [
                     'Title' => $service->getName(),
                     'Service' => Str::studly($service->getId()),

--- a/src/Drivers/DatabaseDriver.php
+++ b/src/Drivers/DatabaseDriver.php
@@ -150,7 +150,7 @@ class DatabaseDriver extends ServiceDriver
         static::putFile(
             config_path($configPath = Str::slug($service->getId()) . '.php'),
             static::makeFile(
-                static::getStub('config-service-database'),
+                static::getStub('config-service-database', $service->getId()),
                 [
                     'Title' => $service->getName(),
                     'Service' => Str::studly($service->getId()),
@@ -170,7 +170,7 @@ class DatabaseDriver extends ServiceDriver
         $providers = $providers->reduce(
             fn ($array, $provider, $index) =>
                 $array . static::makeFile(
-                    static::getStub('migration-service-providers'),
+                    static::getStub('migration-service-providers', $service->getId()),
                     [
                         'id' => $provider['id'],
                         'name' => $provider['name'],
@@ -184,7 +184,7 @@ class DatabaseDriver extends ServiceDriver
         $accounts = $accounts->reduce(
             fn ($array, $account, $index) =>
                 $array . static::makeFile(
-                    static::getStub('migration-service-accounts'),
+                    static::getStub('migration-service-accounts', $service->getId()),
                     [
                         'id' => $account['id'],
                         'name' => $account['name'],
@@ -198,7 +198,7 @@ class DatabaseDriver extends ServiceDriver
         static::putFile(
             database_path($migrationPath = 'migrations/' . Carbon::now()->format('Y_m_d_His') . '_add_providers_and_accounts_to_' . Str::slug($service->getId(), '_') . '_service.php'),
             static::makeFile(
-                static::getStub('migration-service'),
+                static::getStub('migration-service', $service->getId()),
                 [
                     'service' => $service->getId(),
                     'providers' => $providers,

--- a/src/Traits/GeneratesFiles.php
+++ b/src/Traits/GeneratesFiles.php
@@ -45,8 +45,8 @@ trait GeneratesFiles
     /**
      * Get the most relevant stub file.
      *
-     * @param $stub
-     * @param $service
+     * @param string $stub
+     * @param string|null $service
      * @return string
      */
     protected static function getStub($stub, $service = null)


### PR DESCRIPTION
### **What does this PR do?** :robot:
Passes the service id to the `getStub()` function to check whether or not a stub override exists and use it instead.

### **Does this relate to any issue?** :link:
Allows for https://github.com/payavel/checkout/pull/51
