### PR TITLE
[2.x] Publish base migration when database driver is chosen.

### DIFF
--- a/src/Drivers/DatabaseDriver.php
+++ b/src/Drivers/DatabaseDriver.php
@@ -5,6 +5,7 @@ namespace Payavel\Orchestration\Drivers;
 use Exception;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Str;
 use Payavel\Orchestration\Contracts\Accountable;
@@ -147,6 +148,8 @@ class DatabaseDriver extends ServiceDriver
      */
     public static function generateService(Serviceable $service, Collection $providers, Collection $accounts, array $defaults)
     {
+        Artisan::call('vendor:publish', ['--tag' => 'payavel-orchestration-migrations']);
+
         static::putFile(
             config_path($configPath = Str::slug($service->getId()) . '.php'),
             static::makeFile(

--- a/src/OrchestrationServiceProvider.php
+++ b/src/OrchestrationServiceProvider.php
@@ -32,7 +32,7 @@ class OrchestrationServiceProvider extends ServiceProvider
     {
         $this->publishes([
             __DIR__ . '/../database/migrations/2024_01_01_000001_create_base_orchestration_tables.php' => database_path('migrations/2024_01_01_000001_create_base_orchestration_tables.php'),
-        ], ['payavel', 'payavel-orchestration', 'payavel-migrations']);
+        ], ['payavel', 'payavel-orchestration', 'payavel-migrations', 'payavel-orchestration-migrations']);
     }
 
     protected function registerCommands()

--- a/tests/Traits/SetsDatabaseDriver.php
+++ b/tests/Traits/SetsDatabaseDriver.php
@@ -15,5 +15,9 @@ trait SetsDatabaseDriver
     protected function setDriver()
     {
         Config::set('orchestration.defaults.driver', 'database');
+
+        Artisan::call('vendor:publish', [
+            '--tag' => 'payavel-orchestration-migrations'
+        ]);
     }
 }

--- a/tests/Traits/SetsDatabaseDriver.php
+++ b/tests/Traits/SetsDatabaseDriver.php
@@ -15,9 +15,5 @@ trait SetsDatabaseDriver
     protected function setDriver()
     {
         Config::set('orchestration.defaults.driver', 'database');
-
-        Artisan::call('vendor:publish', [
-            '--tag' => 'payavel-migrations'
-        ]);
     }
 }


### PR DESCRIPTION
### **What does this PR do?** :robot:
It publishes the base orchestration migration when the database driver is chosen for a service.

### **How should this be tested?** :microscope:
Run the `php artisan orchestrate:service` command and choose the database driver for your service. After that is done you should see the base orchestration table migration has been published. This should allow you to run `php artisan migrate` and you shall see your service records in the database without any errors of missing tables.

### **Does this relate to any issue?** :link:
Closes #65, discovered in https://github.com/payavel/checkout/issues/53
