### PR TITLE
[2.x] Use DIRECTORY_SEPARATOR to support unix and dos.

### DIFF
--- a/src/Traits/GeneratesFiles.php
+++ b/src/Traits/GeneratesFiles.php
@@ -36,7 +36,7 @@ trait GeneratesFiles
     {
         $fileSystem = new Filesystem();
 
-        $directory = collect(explode('/', $path, -1))->join('/');
+        $directory = collect(explode(DIRECTORY_SEPARATOR, $path, -1))->join(DIRECTORY_SEPARATOR);
         $fileSystem->ensureDirectoryExists($directory);
 
         $fileSystem->put($path, $file);


### PR DESCRIPTION
### **What does this PR do?** :robot:
Fixes the `php artisan orchestrate:service` command on windows.

### **How should this be tested?** :microscope:
Run the `php artisan orchestrate:service` command on windows.
