### PR TITLE
[2.x] Fix `orchestrate` commands not working on Windows.

### DIFF
--- a/src/Console/Commands/OrchestrateProvider.php
+++ b/src/Console/Commands/OrchestrateProvider.php
@@ -11,6 +11,7 @@ use Payavel\Orchestration\Traits\GeneratesFiles;
 use function Laravel\Prompts\error;
 use function Laravel\Prompts\info;
 use function Laravel\Prompts\select;
+use function Illuminate\Filesystem\join_paths;
 
 class OrchestrateProvider extends Command
 {
@@ -106,7 +107,7 @@ class OrchestrateProvider extends Command
         $provider = Str::studly($this->id);
 
         static::putFile(
-            app_path($requestPath = "Services/{$service}/{$provider}{$service}Request.php"),
+            app_path($requestPath = join_paths('Services', $service, "{$provider}{$service}Request.php")),
             static::makeFile(
                 static::getStub('service-request', $this->service->getId()),
                 [
@@ -116,10 +117,10 @@ class OrchestrateProvider extends Command
             )
         );
 
-        info("Gateway [app/{$requestPath}] created successfully.");
+        info('Gateway ['.join_paths('app', $requestPath).'] created successfully.');
 
         static::putFile(
-            app_path($responsePath = "Services/{$service}/{$provider}{$service}Response.php"),
+            app_path($responsePath = join_paths('Services', $service, "{$provider}{$service}Response.php")),
             static::makeFile(
                 static::getStub('service-response', $this->service->getId()),
                 [
@@ -129,7 +130,7 @@ class OrchestrateProvider extends Command
             )
         );
 
-        info("Gateway [app/{$responsePath}] created successfully.");
+        info('Gateway ['.join_paths('app', $responsePath).'] created successfully.');
     }
 
     /**

--- a/src/Console/Commands/OrchestrateService.php
+++ b/src/Console/Commands/OrchestrateService.php
@@ -268,6 +268,6 @@ class OrchestrateService extends Command
             )
         );
 
-        info('Config ['.join_paths('app', $configPath).'] created successfully.');
+        info('Config ['.join_paths('config', $configPath).'] created successfully.');
     }
 }

--- a/src/Console/Commands/OrchestrateService.php
+++ b/src/Console/Commands/OrchestrateService.php
@@ -13,6 +13,7 @@ use function Laravel\Prompts\confirm;
 use function Laravel\Prompts\info;
 use function Laravel\Prompts\multiselect;
 use function Laravel\Prompts\select;
+use function Illuminate\Filesystem\join_paths;
 
 class OrchestrateService extends Command
 {
@@ -111,7 +112,7 @@ class OrchestrateService extends Command
         $studlyService = Str::studly($this->service->getId());
 
         static::putFile(
-            app_path($requesterPath = "Services/{$studlyService}/Contracts/{$studlyService}Requester.php"),
+            app_path($requesterPath = join_paths('Services', $studlyService, 'Contracts', "{$studlyService}Requester.php")),
             static::makeFile(
                 static::getStub('service-requester', $this->service->getId()),
                 [
@@ -120,10 +121,10 @@ class OrchestrateService extends Command
             )
         );
 
-        info("Contract [app/{$requesterPath}] created successfully.");
+        info('Contract ['.join_paths('app', $requesterPath).'] created successfully.');
 
         static::putFile(
-            app_path($responderPath = "Services/{$studlyService}/Contracts/{$studlyService}Responder.php"),
+            app_path($responderPath = join_paths('Services', $studlyService, 'Contracts', "{$studlyService}Responder.php")),
             static::makeFile(
                 static::getStub('service-responder', $this->service->getId()),
                 [
@@ -132,7 +133,7 @@ class OrchestrateService extends Command
             )
         );
 
-        info("Contract [app/{$responderPath}] created successfully.");
+        info('Contract ['.join_paths('app', $responderPath).'] created successfully.');
     }
 
     /**
@@ -267,6 +268,6 @@ class OrchestrateService extends Command
             )
         );
 
-        info("Config [config/{$configPath}] created successfully.");
+        info('Config ['.join_paths('app', $configPath).'] created successfully.');
     }
 }

--- a/src/Console/Commands/OrchestrateStubs.php
+++ b/src/Console/Commands/OrchestrateStubs.php
@@ -8,6 +8,7 @@ use Payavel\Orchestration\Traits\GeneratesFiles;
 
 use function Laravel\Prompts\error;
 use function Laravel\Prompts\info;
+use function Illuminate\Filesystem\join_paths;
 
 class OrchestrateStubs extends Command
 {
@@ -88,7 +89,7 @@ class OrchestrateStubs extends Command
 
         foreach($stubs as $stub) {
             static::putFile(
-                base_path("{$directory}/{$stub}.stub"),
+                base_path(join_paths($directory, "{$stub}.stub")),
                 file_get_contents(__DIR__."/../../../stubs/{$stub}.stub")
             );
         }

--- a/src/DataTransferObjects/Account.php
+++ b/src/DataTransferObjects/Account.php
@@ -59,17 +59,17 @@ class Account implements Accountable
     public function getProviders()
     {
         if (! isset($this->providers)) {
-            $this->attributes['providers'] = (new Collection(ServiceConfig::get($this->service, 'accounts.' . $this->attributes['id'] . '.providers', [])))
+            $this->attributes['providers'] = (new Collection(ServiceConfig::get($this->service, 'accounts.'.$this->attributes['id'].'.providers', [])))
                 ->map(
                     fn ($provider, $key) => is_array($provider)
                         ? array_merge(
                             ['id' => $key],
-                            ServiceConfig::get($this->service, 'providers.' . $key),
+                            ServiceConfig::get($this->service, 'providers.'.$key),
                             $provider
                         )
                         : array_merge(
                             ['id' => $provider],
-                            ServiceConfig::get($this->service, 'providers.' . $provider)
+                            ServiceConfig::get($this->service, 'providers.'.$provider)
                         )
                 );
         }

--- a/src/Drivers/ConfigDriver.php
+++ b/src/Drivers/ConfigDriver.php
@@ -16,6 +16,7 @@ use Payavel\Orchestration\Traits\GeneratesFiles;
 use Payavel\Orchestration\Support\ServiceConfig;
 
 use function Laravel\Prompts\info;
+use function Illuminate\Filesystem\join_paths;
 
 class ConfigDriver extends ServiceDriver
 {
@@ -216,7 +217,7 @@ class ConfigDriver extends ServiceDriver
         );
 
         static::putFile(
-            config_path($configPath = Str::slug($service->getId()) . '.php'),
+            config_path($configPath = Str::slug($service->getId()).'.php'),
             static::makeFile(
                 static::getStub('config-service', $service->getId()),
                 [
@@ -233,7 +234,7 @@ class ConfigDriver extends ServiceDriver
             )
         );
 
-        info('Config [.'join_paths('config', $configPath).'] created successfully.');
+        info('Config ['.join_paths('config', $configPath).'] created successfully.');
 
         Config::set(Str::slug($service->getId()), require(config_path($configPath)));
     }

--- a/src/Drivers/ConfigDriver.php
+++ b/src/Drivers/ConfigDriver.php
@@ -233,7 +233,7 @@ class ConfigDriver extends ServiceDriver
             )
         );
 
-        info("Config [config/{$configPath}] created successfully.");
+        info('Config [.'join_paths('config', $configPath).'] created successfully.');
 
         Config::set(Str::slug($service->getId()), require(config_path($configPath)));
     }

--- a/src/Drivers/ConfigDriver.php
+++ b/src/Drivers/ConfigDriver.php
@@ -196,7 +196,7 @@ class ConfigDriver extends ServiceDriver
 
         $config['accounts'] = $accounts->reduce(
             fn ($config, $account) =>
-                $config . static::makeFile(
+                $config.static::makeFile(
                     static::getStub('config-service-account', $service->getId()),
                     [
                         'id' => $account['id'],

--- a/src/Drivers/DatabaseDriver.php
+++ b/src/Drivers/DatabaseDriver.php
@@ -33,7 +33,7 @@ class DatabaseDriver extends ServiceDriver
     public function resolveProvider($provider)
     {
         if (! $provider instanceof Provider) {
-            $serviceProvider = ServiceConfig::get($this->service, 'models.' . Provider::class, Provider::class);
+            $serviceProvider = ServiceConfig::get($this->service, 'models.'.Provider::class, Provider::class);
 
             $provider = $serviceProvider::find($provider);
         }
@@ -69,7 +69,7 @@ class DatabaseDriver extends ServiceDriver
     public function resolveAccount($account)
     {
         if (! $account instanceof Account) {
-            $serviceAccount = ServiceConfig::get($this->service, 'models.' . Account::class, Account::class);
+            $serviceAccount = ServiceConfig::get($this->service, 'models.'.Account::class, Account::class);
 
             $account = $serviceAccount::find($account);
         }
@@ -152,7 +152,7 @@ class DatabaseDriver extends ServiceDriver
         Artisan::call('vendor:publish', ['--tag' => 'payavel-orchestration-migrations']);
 
         static::putFile(
-            config_path($configPath = Str::slug($service->getId()) . '.php'),
+            config_path($configPath = Str::slug($service->getId()).'.php'),
             static::makeFile(
                 static::getStub('config-service-database', $service->getId()),
                 [
@@ -173,7 +173,7 @@ class DatabaseDriver extends ServiceDriver
 
         $providers = $providers->reduce(
             fn ($array, $provider, $index) =>
-                $array . static::makeFile(
+                $array.static::makeFile(
                     static::getStub('migration-service-providers', $service->getId()),
                     [
                         'id' => $provider['id'],
@@ -187,7 +187,7 @@ class DatabaseDriver extends ServiceDriver
 
         $accounts = $accounts->reduce(
             fn ($array, $account, $index) =>
-                $array . static::makeFile(
+                $array.static::makeFile(
                     static::getStub('migration-service-accounts', $service->getId()),
                     [
                         'id' => $account['id'],
@@ -200,7 +200,7 @@ class DatabaseDriver extends ServiceDriver
         );
 
         static::putFile(
-            database_path($migrationPath = join_paths('migrations', Carbon::now()->format('Y_m_d_His') . '_add_providers_and_accounts_to_' . Str::slug($service->getId(), '_')) . '_service.php'),
+            database_path($migrationPath = join_paths('migrations', Carbon::now()->format('Y_m_d_His').'_add_providers_and_accounts_to_'.Str::slug($service->getId(), '_')).'_service.php'),
             static::makeFile(
                 static::getStub('migration-service', $service->getId()),
                 [

--- a/src/Drivers/DatabaseDriver.php
+++ b/src/Drivers/DatabaseDriver.php
@@ -166,7 +166,7 @@ class DatabaseDriver extends ServiceDriver
             )
         );
 
-        info("Config [config/{$configPath}] created successfully.");
+        info('Config ['.join_paths('config', $configPath).'] created successfully.');
 
         Config::set(Str::slug($service->getId()), require(config_path($configPath)));
 
@@ -199,7 +199,7 @@ class DatabaseDriver extends ServiceDriver
         );
 
         static::putFile(
-            database_path($migrationPath = 'migrations/' . Carbon::now()->format('Y_m_d_His') . '_add_providers_and_accounts_to_' . Str::slug($service->getId(), '_') . '_service.php'),
+            database_path($migrationPath = join_paths('migrations', Carbon::now()->format('Y_m_d_His') . '_add_providers_and_accounts_to_' . Str::slug($service->getId(), '_')) . '_service.php'),
             static::makeFile(
                 static::getStub('migration-service', $service->getId()),
                 [

--- a/src/Drivers/DatabaseDriver.php
+++ b/src/Drivers/DatabaseDriver.php
@@ -18,6 +18,7 @@ use Payavel\Orchestration\Traits\GeneratesFiles;
 use Payavel\Orchestration\Support\ServiceConfig;
 
 use function Laravel\Prompts\info;
+use function Illuminate\Filesystem\join_paths;
 
 class DatabaseDriver extends ServiceDriver
 {

--- a/src/OrchestrationServiceProvider.php
+++ b/src/OrchestrationServiceProvider.php
@@ -23,7 +23,7 @@ class OrchestrationServiceProvider extends ServiceProvider
     public function register()
     {
         $this->mergeConfigFrom(
-            __DIR__ . '/../config/orchestration.php',
+            __DIR__.'/../config/orchestration.php',
             'orchestration'
         );
     }
@@ -31,7 +31,7 @@ class OrchestrationServiceProvider extends ServiceProvider
     protected function registerPublishableAssets()
     {
         $this->publishes([
-            __DIR__ . '/../database/migrations/2024_01_01_000001_create_base_orchestration_tables.php' => database_path('migrations/2024_01_01_000001_create_base_orchestration_tables.php'),
+            __DIR__.'/../database/migrations/2024_01_01_000001_create_base_orchestration_tables.php' => database_path('migrations/2024_01_01_000001_create_base_orchestration_tables.php'),
         ], ['payavel', 'payavel-orchestration', 'payavel-migrations', 'payavel-orchestration-migrations']);
     }
 

--- a/src/Service.php
+++ b/src/Service.php
@@ -64,7 +64,7 @@ class Service
 
         $this->service = $service;
 
-        if (! class_exists($driver = ServiceConfig::get($this->service, 'drivers.' . ServiceConfig::get($this->service, 'defaults.driver')))) {
+        if (! class_exists($driver = ServiceConfig::get($this->service, 'drivers.'.ServiceConfig::get($this->service, 'defaults.driver')))) {
             throw new Exception('Invalid driver provided.');
         }
 

--- a/src/ServiceRequest.php
+++ b/src/ServiceRequest.php
@@ -64,7 +64,7 @@ abstract class ServiceRequest
     public function request($method, $params)
     {
         if (! method_exists($this, $method)) {
-            throw new \BadMethodCallException(get_class($this) . "::{$method}() not found.");
+            throw new \BadMethodCallException(get_class($this)."::{$method}() not found.");
         }
 
         $response = $this->{$method}(...$params);

--- a/src/Support/ServiceConfig.php
+++ b/src/Support/ServiceConfig.php
@@ -22,16 +22,16 @@ class ServiceConfig
             $service = $service->getId();
         }
 
-        $config = Config::get('orchestration.services.' . $service, Str::slug($service));
+        $config = Config::get('orchestration.services.'.$service, Str::slug($service));
 
         if (is_array($config)) {
-            return Config::get('orchestration.services.' . $service . '.' . $key, $default);
+            return Config::get('orchestration.services.'.$service.'.'.$key, $default);
         }
 
         return Config::get(
-            $config .  '.' . $key,
+            $config.'.'.$key,
             Config::get(
-                'orchestration.' . $key,
+                'orchestration.'.$key,
                 $default
             )
         );
@@ -51,10 +51,10 @@ class ServiceConfig
             $service = $service->getId();
         }
 
-        $config = Config::get('orchestration.services.' . $service, Str::slug($service));
+        $config = Config::get('orchestration.services.'.$service, Str::slug($service));
 
         Config::set(
-            (is_array($config) ? 'orchestration.services.' . $service : $config) . '.' . $key,
+            (is_array($config) ? 'orchestration.services.'.$service : $config).'.'.$key,
             $value
         );
     }

--- a/src/Traits/AsksQuestions.php
+++ b/src/Traits/AsksQuestions.php
@@ -46,6 +46,6 @@ trait AsksQuestions
      */
     private function formatService($entity)
     {
-        return ($this->service ? ($this->service->getName() . ' ') : '') . $entity;
+        return ($this->service ? ($this->service->getName().' ') : '').$entity;
     }
 }

--- a/src/Traits/GeneratesFiles.php
+++ b/src/Traits/GeneratesFiles.php
@@ -36,7 +36,7 @@ trait GeneratesFiles
     {
         $fileSystem = new Filesystem();
 
-        $directory = collect(explode('/', $path, -1))->join('/');
+        $directory = collect(explode(DIRECTORY_SEPARATOR, $path, -1))->join(DIRECTORY_SEPARATOR);
         $fileSystem->ensureDirectoryExists($directory);
 
         $fileSystem->put($path, $file);

--- a/src/Traits/GeneratesFiles.php
+++ b/src/Traits/GeneratesFiles.php
@@ -19,7 +19,7 @@ trait GeneratesFiles
         $file = file_get_contents($stub);
 
         foreach ($data as $search => $replace) {
-            $file = Str::replace('{{ ' . $search . ' }}', $replace, $file);
+            $file = Str::replace('{{ '.$search.' }}', $replace, $file);
         }
 
         return $file;
@@ -65,6 +65,6 @@ trait GeneratesFiles
             return $file;
         }
 
-        return __DIR__ . "/../../stubs/{$stub}.stub";
+        return __DIR__."/../../stubs/{$stub}.stub";
     }
 }

--- a/src/Traits/SimulatesAttributes.php
+++ b/src/Traits/SimulatesAttributes.php
@@ -21,7 +21,7 @@ trait SimulatesAttributes
      */
     public function __get($key)
     {
-        if (! method_exists(self::class, $method = 'get' . Str::studly($key))) {
+        if (! method_exists(self::class, $method = 'get'.Str::studly($key))) {
             return $this->getAttribute($key);
         }
 
@@ -37,7 +37,7 @@ trait SimulatesAttributes
      */
     public function __set($key, $value): void
     {
-        if (! method_exists(self::class, $method = 'set' . Str::studly($key))) {
+        if (! method_exists(self::class, $method = 'set'.Str::studly($key))) {
             $this->setAttribute($key, $value);
 
             return;

--- a/src/Traits/ThrowsRuntimeException.php
+++ b/src/Traits/ThrowsRuntimeException.php
@@ -15,6 +15,6 @@ trait ThrowsRuntimeException
      */
     private function throwRuntimeException($method)
     {
-        throw new RuntimeException(get_class($this) . "::class does not implement the {$method}() method.");
+        throw new RuntimeException(get_class($this)."::class does not implement the {$method}() method.");
     }
 }

--- a/tests/Feature/Console/Commands/ConfigOrchestrateServiceCommandTest.php
+++ b/tests/Feature/Console/Commands/ConfigOrchestrateServiceCommandTest.php
@@ -16,19 +16,19 @@ class ConfigOrchestrateServiceCommandTest extends TestOrchestrateServiceCommand
 
     protected function makeSureProviderExists(Serviceable $service, Providable $provider)
     {
-        $config = require(config_path(Str::slug($service->getId()) . '.php'));
+        $config = require(config_path(Str::slug($service->getId()).'.php'));
 
         $this->assertIsArray($config['providers']);
         $this->assertIsArray($config['providers'][$provider->getId()]);
         $this->assertEquals(
-            'App\\Services\\' . Str::studly($service->getId()) . '\\' . Str::studly($provider->getId()) . Str::studly($service->getId()) . 'Request',
+            'App\\Services\\'.Str::studly($service->getId()).'\\'.Str::studly($provider->getId()).Str::studly($service->getId()).'Request',
             $config['providers'][$provider->getId()]['gateway']
         );
     }
 
     protected function makeSureAccountExists(Serviceable $service, Accountable $account)
     {
-        $config = require(config_path(Str::slug($service->getId()) . '.php'));
+        $config = require(config_path(Str::slug($service->getId()).'.php'));
 
         $this->assertIsArray($config['accounts']);
         $this->assertIsArray($config['accounts'][$account->getId()]);
@@ -38,7 +38,7 @@ class ConfigOrchestrateServiceCommandTest extends TestOrchestrateServiceCommand
 
     protected function makeSureProviderIsLinkedToAccount(Serviceable $service, Providable $provider, Accountable $account)
     {
-        $config = require(config_path(Str::slug($service->getId()) . '.php'));
+        $config = require(config_path(Str::slug($service->getId()).'.php'));
 
         $this->assertIsArray($config['accounts'][$account->getId()]['providers'][$provider->getId()]);
     }

--- a/tests/Feature/Console/Commands/DatabaseOrchestrateServiceCommandTest.php
+++ b/tests/Feature/Console/Commands/DatabaseOrchestrateServiceCommandTest.php
@@ -31,7 +31,7 @@ class DatabaseOrchestrateServiceCommandTest extends TestOrchestrateServiceComman
 
         $this->assertNotNull($provider);
         $this->assertEquals(
-            'App\\Services\\' . Str::studly($service->getId()) . '\\' . Str::studly($provider->getId()) . Str::studly($service->getId()) . 'Request',
+            'App\\Services\\'.Str::studly($service->getId()).'\\'.Str::studly($provider->getId()).Str::studly($service->getId()).'Request',
             $provider->gateway
         );
     }

--- a/tests/Feature/Console/Commands/OrchestrateStubsCommandTest.php
+++ b/tests/Feature/Console/Commands/OrchestrateStubsCommandTest.php
@@ -16,7 +16,7 @@ class OrchestrateStubsCommandTest extends TestCase
             ->assertExitCode(0);
 
         foreach(OrchestrateStubs::$baseStubs as $stub) {
-            $this->assertFileExists(base_path('stubs/orchestration/' . $stub . '.stub'));
+            $this->assertFileExists(base_path('stubs/orchestration/'.$stub.'.stub'));
         }
     }
 
@@ -30,7 +30,7 @@ class OrchestrateStubsCommandTest extends TestCase
             ->assertExitCode(0);
 
         foreach(OrchestrateStubs::$serviceSpecificStubs as $stub) {
-            $this->assertFileExists(base_path('stubs/orchestration/mock/' . $stub . '.stub'));
+            $this->assertFileExists(base_path('stubs/orchestration/mock/'.$stub.'.stub'));
         }
     }
 
@@ -43,7 +43,7 @@ class OrchestrateStubsCommandTest extends TestCase
             ->expectsOutputToContain('Successfully published stub!')
             ->assertExitCode(0);
 
-        $this->assertFileExists(base_path('stubs/orchestration/' . $stub . '.stub'));
+        $this->assertFileExists(base_path('stubs/orchestration/'.$stub.'.stub'));
     }
 
     #[Test]

--- a/tests/Feature/Console/Commands/TestOrchestrateProviderCommand.php
+++ b/tests/Feature/Console/Commands/TestOrchestrateProviderCommand.php
@@ -24,12 +24,13 @@ abstract class TestOrchestrateProviderCommand extends TestCase implements Create
 
         $gateway = $this->gatewayPath($provider);
 
+        $ds = DIRECTORY_SEPARATOR;
         $this->artisan('orchestrate:provider')
             ->expectsQuestion('Which service will the provider be offering?', $services->search($service->getId()))
             ->expectsQuestion("How should the {$service->getName()} provider be named?", $provider->getName())
             ->expectsQuestion("How should the {$service->getName()} provider be identified?", $provider->getId())
-            ->expectsOutputToContain("Gateway [app/{$gateway->request}] created successfully.")
-            ->expectsOutputToContain("Gateway [app/{$gateway->response}] created successfully.")
+            ->expectsOutputToContain("Gateway [app{$ds}{$gateway->request}] created successfully.")
+            ->expectsOutputToContain("Gateway [app{$ds}{$gateway->response}] created successfully.")
             ->assertSuccessful();
 
         $this->assertGatewayExists($provider);
@@ -42,13 +43,14 @@ abstract class TestOrchestrateProviderCommand extends TestCase implements Create
 
         $gateway = $this->gatewayPath($provider);
 
+        $ds = DIRECTORY_SEPARATOR;
         $this->artisan('orchestrate:provider', [
             'provider' => $provider->getName(),
             '--id' => $provider->getId(),
             '--service' => $provider->getService()->getId(),
         ])
-            ->expectsOutputToContain("Gateway [app/{$gateway->request}] created successfully.")
-            ->expectsOutputToContain("Gateway [app/{$gateway->response}] created successfully.")
+            ->expectsOutputToContain("Gateway [app{$ds}{$gateway->request}] created successfully.")
+            ->expectsOutputToContain("Gateway [app{$ds}{$gateway->response}] created successfully.")
             ->assertSuccessful();
 
         $this->assertGatewayExists($provider);
@@ -61,12 +63,13 @@ abstract class TestOrchestrateProviderCommand extends TestCase implements Create
 
         $gateway = $this->gatewayPath($service);
 
+        $ds = DIRECTORY_SEPARATOR;
         $this->artisan('orchestrate:provider', [
             '--service' => $service->getId(),
             '--fake' => true,
         ])
-            ->expectsOutputToContain("Gateway [app/{$gateway->request}] created successfully.")
-            ->expectsOutputToContain("Gateway [app/{$gateway->response}] created successfully.")
+            ->expectsOutputToContain("Gateway [app{$ds}{$gateway->request}] created successfully.")
+            ->expectsOutputToContain("Gateway [app{$ds}{$gateway->response}] created successfully.")
             ->assertSuccessful();
 
         $this->assertGatewayExists($service);

--- a/tests/Feature/Console/Commands/TestOrchestrateServiceCommand.php
+++ b/tests/Feature/Console/Commands/TestOrchestrateServiceCommand.php
@@ -29,6 +29,7 @@ abstract class TestOrchestrateServiceCommand extends TestCase implements Creates
         $fakeGateway = $this->gatewayPath($service);
         $providerGateway = $this->gatewayPath($provider);
 
+        $ds = DIRECTORY_SEPARATOR;
         $this->artisan('orchestrate:service', [
             'service' => $service->getName(),
             '--id' => $service->getId(),
@@ -40,14 +41,14 @@ abstract class TestOrchestrateServiceCommand extends TestCase implements Creates
             ->expectsQuestion("How should the {$service->getName()} account be named?", $account->getName())
             ->expectsQuestion("How should the {$service->getName()} account be identified?", $account->getId())
             ->expectsConfirmation("Would you like to add another {$service->getName()} account?", 'no')
-            ->expectsOutputToContain("Config [config/{$serviceConfig->orchestration}] created successfully.")
-            ->expectsOutputToContain("Config [config/{$serviceConfig->service}] created successfully.")
-            ->expectsOutputToContain("Contract [app/{$serviceContract->requester}] created successfully.")
-            ->expectsOutputToContain("Contract [app/{$serviceContract->responder}] created successfully.")
-            ->expectsOutputToContain("Gateway [app/{$fakeGateway->request}] created successfully.")
-            ->expectsOutputToContain("Gateway [app/{$fakeGateway->response}] created successfully.")
-            ->expectsOutputToContain("Gateway [app/{$providerGateway->request}] created successfully.")
-            ->expectsOutputToContain("Gateway [app/{$providerGateway->response}] created successfully.")
+            ->expectsOutputToContain("Config [config{$ds}{$serviceConfig->orchestration}] created successfully.")
+            ->expectsOutputToContain("Config [config{$ds}{$serviceConfig->service}] created successfully.")
+            ->expectsOutputToContain("Contract [app{$ds}{$serviceContract->requester}] created successfully.")
+            ->expectsOutputToContain("Contract [app{$ds}{$serviceContract->responder}] created successfully.")
+            ->expectsOutputToContain("Gateway [app{$ds}{$fakeGateway->request}] created successfully.")
+            ->expectsOutputToContain("Gateway [app{$ds}{$fakeGateway->response}] created successfully.")
+            ->expectsOutputToContain("Gateway [app{$ds}{$providerGateway->request}] created successfully.")
+            ->expectsOutputToContain("Gateway [app{$ds}{$providerGateway->response}] created successfully.")
             ->assertSuccessful();
 
         $config = require(config_path($serviceConfig->service));
@@ -84,6 +85,7 @@ abstract class TestOrchestrateServiceCommand extends TestCase implements Creates
         $provider1Gateway = $this->gatewayPath($provider1);
         $provider2Gateway = $this->gatewayPath($provider2);
 
+        $ds = DIRECTORY_SEPARATOR;
         $this->artisan('orchestrate:service')
             ->expectsQuestion('How should the service be named?', $service->getName())
             ->expectsQuestion('How should the service be identified?', $service->getId())
@@ -108,16 +110,16 @@ abstract class TestOrchestrateServiceCommand extends TestCase implements Creates
             ->expectsQuestion("Choose one or more {$service->getName()} providers for the {$account3->getName()} account.", [$provider1->getId(), $provider2->getId()])
             ->expectsConfirmation("Would you like to add another {$service->getName()} account?", 'no')
             ->expectsQuestion("Which account will be used as default?", $account1->getId())
-            ->expectsOutputToContain("Config [config/{$serviceConfig->orchestration}] created successfully.")
-            ->expectsOutputToContain("Config [config/{$serviceConfig->service}] created successfully.")
-            ->expectsOutputToContain("Contract [app/{$serviceContract->requester}] created successfully.")
-            ->expectsOutputToContain("Contract [app/{$serviceContract->responder}] created successfully.")
-            ->expectsOutputToContain("Gateway [app/{$fakeGateway->request}] created successfully.")
-            ->expectsOutputToContain("Gateway [app/{$fakeGateway->response}] created successfully.")
-            ->expectsOutputToContain("Gateway [app/{$provider1Gateway->request}] created successfully.")
-            ->expectsOutputToContain("Gateway [app/{$provider1Gateway->response}] created successfully.")
-            ->expectsOutputToContain("Gateway [app/{$provider2Gateway->request}] created successfully.")
-            ->expectsOutputToContain("Gateway [app/{$provider2Gateway->response}] created successfully.")
+            ->expectsOutputToContain("Config [config{$ds}{$serviceConfig->orchestration}] created successfully.")
+            ->expectsOutputToContain("Config [config{$ds}{$serviceConfig->service}] created successfully.")
+            ->expectsOutputToContain("Contract [app{$ds}{$serviceContract->requester}] created successfully.")
+            ->expectsOutputToContain("Contract [app{$ds}{$serviceContract->responder}] created successfully.")
+            ->expectsOutputToContain("Gateway [app{$ds}{$fakeGateway->request}] created successfully.")
+            ->expectsOutputToContain("Gateway [app{$ds}{$fakeGateway->response}] created successfully.")
+            ->expectsOutputToContain("Gateway [app{$ds}{$provider1Gateway->request}] created successfully.")
+            ->expectsOutputToContain("Gateway [app{$ds}{$provider1Gateway->response}] created successfully.")
+            ->expectsOutputToContain("Gateway [app{$ds}{$provider2Gateway->request}] created successfully.")
+            ->expectsOutputToContain("Gateway [app{$ds}{$provider2Gateway->response}] created successfully.")
             ->assertSuccessful();
 
         $config = require(config_path($serviceConfig->service));

--- a/tests/Services/Mock/FakeMockResponse.php
+++ b/tests/Services/Mock/FakeMockResponse.php
@@ -33,6 +33,6 @@ class FakeMockResponse extends ServiceResponse implements MockResponder
 
     public function getIdentityResponse()
     {
-        return 'Fake' . (is_null($this->additionalInformation) ? '' : ' with ' . $this->additionalInformation);
+        return 'Fake'.(is_null($this->additionalInformation) ? '' : ' with '.$this->additionalInformation);
     }
 }

--- a/tests/Services/Mock/TestMockResponse.php
+++ b/tests/Services/Mock/TestMockResponse.php
@@ -33,6 +33,6 @@ class TestMockResponse extends ServiceResponse implements MockResponder
 
     public function getIdentityResponse()
     {
-        return 'Real' . (is_null($this->additionalInformation) ? '' : ' with ' . $this->additionalInformation);
+        return 'Real'.(is_null($this->additionalInformation) ? '' : ' with '.$this->additionalInformation);
     }
 }

--- a/tests/Traits/AssertsServiceExists.php
+++ b/tests/Traits/AssertsServiceExists.php
@@ -23,9 +23,10 @@ trait AssertsServiceExists
     {
         $service = Str::studly($serviceable->getId());
 
+        $ds = DIRECTORY_SEPARATOR;
         return new Fluent([
-            'requester' => "Services/{$service}/Contracts/{$service}Requester.php",
-            'responder' => "Services/{$service}/Contracts/{$service}Responder.php",
+            'requester' => "Services{$ds}{$service}{$ds}Contracts{$ds}{$service}Requester.php",
+            'responder' => "Services{$ds}{$service}{$ds}Contracts{$ds}{$service}Responder.php",
         ]);
     }
 
@@ -39,9 +40,10 @@ trait AssertsServiceExists
             $provider = 'Fake';
         }
 
+        $ds = DIRECTORY_SEPARATOR;
         return new Fluent([
-            'request' => "Services/{$service}/{$provider}{$service}Request.php",
-            'response' => "Services/{$service}/{$provider}{$service}Response.php",
+            'request' => "Services{$ds}{$service}{$ds}{$provider}{$service}Request.php",
+            'response' => "Services{$ds}{$service}{$ds}{$provider}{$service}Response.php",
         ]);
     }
 

--- a/tests/Traits/CreatesConfigServiceables.php
+++ b/tests/Traits/CreatesConfigServiceables.php
@@ -27,11 +27,11 @@ trait CreatesConfigServiceables
 
         $data['name'] = $data['name'] ?? Str::remove(['\'', ','], $this->faker->unique()->company());
         $data['id'] = $data['id'] ?? preg_replace('/[^a-z0-9]+/i', '_', strtolower($data['name']));
-        $data['gateway'] = $data['gateway'] ?? 'App\\Services\\' . Str::studly($service->getId()) . '\\' . Str::studly($data['id']) . Str::studly($service->getId()) . 'Request';
+        $data['gateway'] = $data['gateway'] ?? 'App\\Services\\'.Str::studly($service->getId()).'\\'.Str::studly($data['id']).Str::studly($service->getId()).'Request';
 
         ServiceConfig::set(
             $service,
-            'providers.' . $data['id'],
+            'providers.'.$data['id'],
             [
                 'name' => $data['name'],
                 'gateway' => $data['gateway']
@@ -57,7 +57,7 @@ trait CreatesConfigServiceables
         $data['name'] = $data['name'] ?? Str::remove(['\'', ','], $this->faker->unique()->company());
         $data['id'] = $data['id'] ?? preg_replace('/[^a-z0-9]+/i', '_', strtolower($data['name']));
 
-        ServiceConfig::set($service, 'accounts.' . $data['id'], ['name' => $data['name']]);
+        ServiceConfig::set($service, 'accounts.'.$data['id'], ['name' => $data['name']]);
 
         return new Account($service, $data);
     }
@@ -74,9 +74,9 @@ trait CreatesConfigServiceables
     {
         ServiceConfig::set(
             $account->getService(),
-            'accounts.' . $account->getId() . '.providers',
+            'accounts.'.$account->getId().'.providers',
             array_merge(
-                ServiceConfig::get($account->getService(), 'accounts.' . $account->getId() . '.providers', []),
+                ServiceConfig::get($account->getService(), 'accounts.'.$account->getId().'.providers', []),
                 [$provider->getId() => $data]
             )
         );

--- a/tests/Traits/CreatesServices.php
+++ b/tests/Traits/CreatesServices.php
@@ -23,9 +23,9 @@ trait CreatesServices
     {
         $data['name'] = $data['name'] ?? Str::ucfirst($this->faker->unique()->word());
         $data['id'] = $data['id'] ?? Str::slug($data['name'], '_');
-        $data['test_gateway'] = $data['test_gateway'] ?? '\\App\\Services\\' . Str::studly($data['id']) . '\\Fake' . Str::studly($data['id']) . 'Request';
+        $data['test_gateway'] = $data['test_gateway'] ?? '\\App\\Services\\'.Str::studly($data['id']).'\\Fake'.Str::studly($data['id']).'Request';
 
-        Config::set('orchestration.services.' . $data['id'], Str::slug($data['id']));
+        Config::set('orchestration.services.'.$data['id'], Str::slug($data['id']));
 
         ServiceConfig::set($data['id'], 'name', $data['name']);
         ServiceConfig::set($data['id'], 'testing.gateway', $data['test_gateway']);
@@ -51,7 +51,7 @@ trait CreatesServices
 
         if (is_null($provider) && ! is_null($account)) {
             $provider = Collection::make(
-                ServiceConfig::get($service, 'accounts.' . $account->getId() . '.providers')
+                ServiceConfig::get($service, 'accounts.'.$account->getId().'.providers')
             )
                 ->keys()
                 ->first();

--- a/tests/Unit/TestService.php
+++ b/tests/Unit/TestService.php
@@ -124,7 +124,7 @@ abstract class TestService extends TestCase implements CreatesServiceables
             $incompatibleAccount = $this->createAccount($this->serviceable);
 
             $this->expectException(Exception::class);
-            $this->expectExceptionMessage('The ' . $incompatibleAccount->getName() . ' account is not supported by the ' . $this->providable->getName() . ' provider.');
+            $this->expectExceptionMessage('The '.$incompatibleAccount->getName().' account is not supported by the '.$this->providable->getName().' provider.');
 
             $this->service->provider($this->providable)->account($incompatibleAccount)->getIdentity();
         });
@@ -154,7 +154,7 @@ abstract class TestService extends TestCase implements CreatesServiceables
 
         $this->assertRealIsAlignedWithFake(function () use ($undefinedMethod) {
             $this->expectException(BadMethodCallException::class);
-            $this->expectExceptionMessage(get_class($this->service->gateway) . "::{$undefinedMethod}() not found.");
+            $this->expectExceptionMessage(get_class($this->service->gateway)."::{$undefinedMethod}() not found.");
 
             $this->service->{$undefinedMethod}();
         });


### PR DESCRIPTION
### **What does this PR do?** :robot:
- All commands this package offers, now work on windows.

### **How should this be tested?** :microscope:
- Require this package in a Laravel project using `composer require payavel/orchestration:dev-bug-windows_directory_seperator`.
- Test this with all 3 commands (`orchestrate:service`, `orchestrate:provider` & `orchestrate:stubs`).
