### PR TITLE
[2.x] Rename `$additionalInformation` to `$additionalData`.

### DIFF
--- a/src/ServiceResponse.php
+++ b/src/ServiceResponse.php
@@ -34,11 +34,11 @@ abstract class ServiceResponse
     protected $rawResponse;
 
     /**
-     * Additional information needed to format the response.
+     * Additional data needed to format the response.
      *
      * @var mixed
      */
-    protected $additionalInformation;
+    protected $additionalData;
 
     /**
      * The request method that returned this response.
@@ -70,13 +70,12 @@ abstract class ServiceResponse
 
     /**
      * @param mixed $rawResponse
-     * @param mixed|null $additionalInformation
-     * @deprecated $additonalInformation will be removed, use with() instead.
+     * @param mixed|null $additionalData
      */
-    public function __construct($rawResponse, $additionalInformation = null)
+    public function __construct($rawResponse, $additionalData = null)
     {
         $this->rawResponse = $rawResponse;
-        $this->additionalInformation = $additionalInformation;
+        $this->additionalData = $additionalData;
 
         $this->setUp();
     }
@@ -92,15 +91,15 @@ abstract class ServiceResponse
     }
 
     /**
-     * Share additional information.
+     * Share additional data.
      *
-     * @param mixed $additionalInformation
+     * @param mixed $additionalData
      *
      * @return static
      */
-    public function with($additionalInformation)
+    public function with($additionalData)
     {
-        $this->additionalInformation = $additionalInformation;
+        $this->additionalData = $additionalData;
 
         return $this;
     }

--- a/tests/Services/Mock/FakeMockRequest.php
+++ b/tests/Services/Mock/FakeMockRequest.php
@@ -7,12 +7,12 @@ use Payavel\Orchestration\Tests\Services\Mock\Contracts\MockRequester;
 
 class FakeMockRequest extends ServiceRequest implements MockRequester
 {
-    public function getIdentity($withAdditionalInformation = false)
+    public function getIdentity($withAdditionalData = false)
     {
         $response = [];
 
-        if ($withAdditionalInformation) {
-            $response = $this->response($response)->with('additional information');
+        if ($withAdditionalData) {
+            $response = $this->response($response)->with('additional data');
         }
 
         return $response;

--- a/tests/Services/Mock/FakeMockResponse.php
+++ b/tests/Services/Mock/FakeMockResponse.php
@@ -33,6 +33,6 @@ class FakeMockResponse extends ServiceResponse implements MockResponder
 
     public function getIdentityResponse()
     {
-        return 'Fake'.(is_null($this->additionalInformation) ? '' : ' with '.$this->additionalInformation);
+        return 'Fake'.(is_null($this->additionalData) ? '' : ' with '.$this->additionalData);
     }
 }

--- a/tests/Services/Mock/TestMockRequest.php
+++ b/tests/Services/Mock/TestMockRequest.php
@@ -7,12 +7,12 @@ use Payavel\Orchestration\Tests\Services\Mock\Contracts\MockRequester;
 
 class TestMockRequest extends ServiceRequest implements MockRequester
 {
-    public function getIdentity($withAdditionalInformation = false)
+    public function getIdentity($withAdditionalData = false)
     {
         $response = [];
 
-        if ($withAdditionalInformation) {
-            $response = $this->response($response)->with('additional information');
+        if ($withAdditionalData) {
+            $response = $this->response($response)->with('additional data');
         }
 
         return $response;

--- a/tests/Services/Mock/TestMockResponse.php
+++ b/tests/Services/Mock/TestMockResponse.php
@@ -33,6 +33,6 @@ class TestMockResponse extends ServiceResponse implements MockResponder
 
     public function getIdentityResponse()
     {
-        return 'Real'.(is_null($this->additionalInformation) ? '' : ' with '.$this->additionalInformation);
+        return 'Real'.(is_null($this->additionalData) ? '' : ' with '.$this->additionalData);
     }
 }

--- a/tests/Unit/TestService.php
+++ b/tests/Unit/TestService.php
@@ -166,7 +166,7 @@ abstract class TestService extends TestCase implements CreatesServiceables
         $this->assertRealIsAlignedWithFake(function () {
             $response = $this->service->getIdentity(true);
 
-            $this->assertStringEndsWith('additional information', $response->data);
+            $this->assertStringEndsWith('additional data', $response->data);
         });
     }
 


### PR DESCRIPTION
### **What does this PR do?** :robot:
Renames `$additionalInformation` to `$additionalData` in the `ServiceResponse::class`.

### **Does this relate to any issue?** :link:
Closes #56 
