### PR TITLE
[2.x] Merge config recursively.

### DIFF
--- a/src/OrchestrationServiceProvider.php
+++ b/src/OrchestrationServiceProvider.php
@@ -6,9 +6,12 @@ use Illuminate\Support\ServiceProvider;
 use Payavel\Orchestration\Console\Commands\OrchestrateService;
 use Payavel\Orchestration\Console\Commands\OrchestrateProvider;
 use Payavel\Orchestration\Console\Commands\OrchestrateStubs;
+use Payavel\Orchestration\Traits\MergesConfigRecursively;
 
 class OrchestrationServiceProvider extends ServiceProvider
 {
+    use MergesConfigRecursively;
+
     public function boot()
     {
         if (! $this->app->runningInConsole()) {
@@ -22,7 +25,7 @@ class OrchestrationServiceProvider extends ServiceProvider
 
     public function register()
     {
-        $this->mergeConfigFrom(
+        $this->recursivelyMergesConfigFrom(
             __DIR__.'/../config/orchestration.php',
             'orchestration'
         );

--- a/src/Traits/MergesConfigRecursively.php
+++ b/src/Traits/MergesConfigRecursively.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Payavel\Orchestration\Traits;
+
+use Illuminate\Contracts\Foundation\CachesConfiguration;
+
+trait MergesConfigRecursively
+{
+    protected function recursivelyMergesConfigFrom($path, $key)
+    {
+        if (! ($this->app instanceof CachesConfiguration && $this->app->configurationIsCached())) {
+            $config = $this->app->make('config');
+
+            $config->set($key, array_replace_recursive(
+                require $path,
+                $config->get($key, [])
+            ));
+        }
+    }
+}


### PR DESCRIPTION
### **What does this PR do?** :robot:
Merges config recursively instead of solely first level. This allows devs to not have to copy deep configs when overriding a single key in those deep configs.
