### PR TITLE
[3.x] Make `Service::class` properties protected

### DIFF
--- a/src/Fluent/Account.php
+++ b/src/Fluent/Account.php
@@ -13,7 +13,7 @@ class Account extends Fluent implements Accountable
      *
      * @var \Payavel\Orchestration\ServiceConfig
      */
-    private ServiceConfig $serviceConfig;
+    protected ServiceConfig $serviceConfig;
 
     public function __construct(ServiceConfig $serviceConfig, $id)
     {

--- a/src/Models/Account.php
+++ b/src/Models/Account.php
@@ -31,7 +31,7 @@ class Account extends Model implements Accountable
      *
      * @var \Payavel\Orchestration\ServiceConfig
      */
-    private ServiceConfig $serviceConfig;
+    protected ServiceConfig $serviceConfig;
 
     /**
      * Get the accountable id.
@@ -68,7 +68,7 @@ class Account extends Model implements Accountable
      *
      * @return string
      */
-    private function getProviderModelClass()
+    protected function getProviderModelClass()
     {
         if(!isset($this->providerModelClass)) {
             $this->providerModelClass = $this->guessProviderModelClass();
@@ -86,7 +86,7 @@ class Account extends Model implements Accountable
      *
      * @return string
      */
-    private function guessProviderModelClass()
+    protected function guessProviderModelClass()
     {
         $parentClass = get_class($this);
 

--- a/src/Models/Provider.php
+++ b/src/Models/Provider.php
@@ -31,7 +31,7 @@ class Provider extends Model implements Providable
      *
      * @var \Payavel\Orchestration\ServiceConfig
      */
-    private ServiceConfig $serviceConfig;
+    protected ServiceConfig $serviceConfig;
 
     /**
      * Get the providable id.
@@ -68,7 +68,7 @@ class Provider extends Model implements Providable
      *
      * @return string
      */
-    private function getAccountModelClass()
+    protected function getAccountModelClass()
     {
         if(!isset($this->accountModelClass)) {
             $this->accountModelClass = $this->guessAccountModelClass();
@@ -87,7 +87,7 @@ class Provider extends Model implements Providable
      *
      * @return string
      */
-    private function guessAccountModelClass()
+    protected function guessAccountModelClass()
     {
         $parentClass = get_class($this);
 

--- a/src/Service.php
+++ b/src/Service.php
@@ -15,35 +15,35 @@ class Service
      *
      * @var \Payavel\Orchestration\ServiceConfig
      */
-    private $config;
+    protected $config;
 
     /**
      * The service driver that will handle provider/account gateway resolutions.
      *
      * @var \Payavel\Orchestration\ServiceDriver
      */
-    private $driver;
+    protected $driver;
 
     /**
      * The configured provider.
      *
      * @var \Payavel\Orchestration\Contracts\Providable
      */
-    private $provider;
+    protected $provider;
 
     /**
      * The configured account.
      *
      * @var \Payavel\Orchestration\Contracts\Accountable
      */
-    private $account;
+    protected $account;
 
     /**
      * The gateway class where requests will be executed.
      *
      * @var \Payavel\Orchestration\ServiceRequest
      */
-    private $gateway;
+    protected $gateway;
 
     /**
      * Sets the service config and the driver for it.

--- a/src/Traits/ThrowsRuntimeException.php
+++ b/src/Traits/ThrowsRuntimeException.php
@@ -13,7 +13,7 @@ trait ThrowsRuntimeException
      *
      * @throws \RuntimeException
      */
-    private function throwRuntimeException($method)
+    protected function throwRuntimeException($method)
     {
         throw new RuntimeException(get_class($this)."::class does not implement the {$method}() method.");
     }


### PR DESCRIPTION
### What the diff?
* **Enhanced variable accessibility in Account class**
Changed '$serviceConfig' property's visibility from private to protected in multiple files.
* **Improved variable accessibility in Provider class**
Updated '$serviceConfig' property's accessibility from private to protected.
* **Modified Service class variable's access**
Adjusted the visibility of '$config', '$driver', '$provider', '$account', and '$gateway' from private to protected.
* **Increased method accessibility in ThrowsRuntimeException trait**
Updated 'throwRuntimeException' method's access from private to protected.
